### PR TITLE
Corrected the casing of Gevent

### DIFF
--- a/modules/ROOT/pages/async-programming.adoc
+++ b/modules/ROOT/pages/async-programming.adoc
@@ -130,7 +130,7 @@ def do_view_query(cb):
 
 == Gevent
 
-http://www.gevent.org[gevent^] is a high performance asynchronous framework.
+http://www.gevent.org[Gevent^] is a high performance asynchronous framework.
 It is very powerful in that it allows for a (mostly) traditional synchronous coding style.
 It accomplishes this by using coroutines known as [.term]_greenlets_ or [.term]_eventlets_.
 


### PR DESCRIPTION
the gevent word should start with capital G as its the starting of the paragraph