### PR TITLE
Update the variables passed to CertAuth

### DIFF
--- a/modules/ROOT/pages/sdk-authentication-overview.adoc
+++ b/modules/ROOT/pages/sdk-authentication-overview.adoc
@@ -60,9 +60,9 @@ bucket_name = "default"
 # the script in etc/x509-cert will generate these
 
 clientdir = "etc/x509-cert/SSLCA/clientdir"
-options = dict(certpath=os.path.join(clientdir, "client.pem"),
-    truststorepath=os.path.join(clientdir, "trust.pem"),
-    keypath=os.path.join(clientdir, "client.key"))
+options = dict(cert_path=os.path.join(clientdir, "client.pem"),
+    trust_store_path=os.path.join(clientdir, "trust.pem"),
+    key_path=os.path.join(clientdir, "client.key"))
 
 # create a Cluster object
 


### PR DESCRIPTION
According to the code, the dict defined in this example is not compatible with the [CertAuthenticator](https://github.com/couchbase/couchbase-python-client/blob/2.5.9/couchbase/cluster.py#L474) class.

Following the example you'll run into:

```python
TypeError: __init__() got an unexpected keyword argument 'certpath'
```

Should probably be changed in the [dev-guide-examples](https://github.com/couchbaselabs/devguide-examples/blob/master/python/connecting-ssl.py)