### PR TITLE
PYCBC-689, DOC-5215: SDK 3.0.0: Migration guide draft 1.0

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -53,13 +53,13 @@
 // ** xref:concept-docs:certificate-based-authentication.adoc[Cert Auth]
 // ** xref:concept-docs:rbac.adoc[RBAC]
 
-.References
+.Reference
 https://docs.couchbase.com/sdk-api/couchbase-python-client[Python API Reference]
 
 .Project Docs
 * xref:project-docs:sdk-release-notes.adoc[Release Notes]
 * xref:project-docs:compatibility.adoc[Compatibility]
-// ** xref:project-docs:migrating-sdk-code-to-3.n.adoc[Migrating to SDK 3 API]
+** xref:project-docs:migrating-sdk-code-to-3.n.adoc[Migrating to SDK 3 API]
 * xref:project-docs:sdk-licenses.adoc[Licenses]
 * xref:project-docs:get-involved.adoc[Get involved]
  ** https://docs.couchbase.com/home/contribute/index.html[Improve the Docs]

--- a/modules/project-docs/examples/migrating.py
+++ b/modules/project-docs/examples/migrating.py
@@ -45,7 +45,7 @@ from couchbase_v2 import COMPRESS_INOUT
 #tag::connstr[]
 # Will set the compression type to inout
 Cluster.connect(
-    "127.0.0.1?compression=inout",ClusterOptions(PasswordAuthenticator(
+    "couchbases://127.0.0.1?compression=inout",ClusterOptions(PasswordAuthenticator(
     "user",
     "pass")))
 
@@ -55,12 +55,12 @@ collection.compression = COMPRESS_INOUT
 
 #natag::rbac[]
 # add convenience overload when available
-Cluster.connect("127.0.0.1", PasswordAuthenticator("username", "password"))
+Cluster.connect("couchbases://127.0.0.1", ClusterOptions(PasswordAuthenticator("username", "password")))
 #naend::rbac[]
 
 #tag::rbac-full[]
 Cluster.connect(
-    "127.0.0.1",
+    "couchbases://127.0.0.1",
     ClusterOptions(PasswordAuthenticator("username", "password")))
 #end::rbac-full[]
 
@@ -69,7 +69,7 @@ import os
 #tag::certauth[]
 cert_dir=os.path.join(os.path.curdir,"cert_dir")
 
-Cluster.connect("127.0.0.1", ClusterOptions(
+Cluster.connect("couchbases://127.0.0.1", ClusterOptions(
     CertAuthenticator(cert_path="cert.pem",
                       key_path="key.crt",
                       trust_store_path="trust_store.pem"
@@ -77,7 +77,7 @@ Cluster.connect("127.0.0.1", ClusterOptions(
 #end::certauth[]
 
 #tag::simpleget[]
-cluster = Cluster.connect("127.0.0.1", ClusterOptions(PasswordAuthenticator("user", "pass")))
+cluster = Cluster.connect("couchbases://127.0.0.1", ClusterOptions(PasswordAuthenticator("user", "pass")))
 bucket = cluster.bucket("travel-sample")
 collection = bucket.default_collection()
 
@@ -85,7 +85,7 @@ get_result = collection.get("airline_10")
 
 #end::simpleget[]
 
-cluster = Cluster.connect("127.0.0.1", ClusterOptions(PasswordAuthenticator("user", "pass")))
+cluster = Cluster.connect("couchbases://127.0.0.1", ClusterOptions(PasswordAuthenticator("user", "pass")))
 bucket = cluster.bucket("travel-sample")
 collection = bucket.default_collection()
 
@@ -163,7 +163,7 @@ bucket.query(
 bucket.query(
     "select * from bucket where type = $1",
     "airport")
-
+# end::queryparameterized_sdk2[]
 del bucket
 
 # tag::queryparameterized[]

--- a/modules/project-docs/examples/migrating.py
+++ b/modules/project-docs/examples/migrating.py
@@ -1,0 +1,259 @@
+from datetime import timedelta
+from couchbase.cluster import Cluster
+from couchbase.collection import GetOptions
+class Migrating(object):
+    pass
+
+#tag::timeoutbuilder[]
+# SDK 3 equivalent
+cluster=Cluster("couchbases://10.192.1.104")
+collection=cluster.bucket("default").default_collection()
+collection.timeout=5
+#end::timeoutbuilder[]
+
+# not applicable
+#natag::shutdown[]
+# ClusterEnvironment env = ClusterEnvironment.create();
+# Cluster cluster = Cluster.connect(
+#     "127.0.0.1",
+#                   // pass the custom environment through the cluster options
+# clusterOptions("user", "pass").environment(env)
+# );
+#
+# // first disconnect, then shutdown the environment
+# cluster.disconnect();
+# env.shutdown();
+#naend::shutdown[]
+
+
+#natag::sysprops[]
+# not applicable
+# Will set the max http connections to 23
+# System.setProperty("com.couchbase.env.io.maxHttpConnections", "23");
+# Cluster.connect("127.0.0.1", "user", "pass");
+#
+# #This is equivalent to
+# ClusterEnvironment env = ClusterEnvironment \
+#     .builder() \
+#     .ioConfig(IoConfig.maxHttpConnections(23)) \
+#     .build();
+#naend::sysprops[]
+
+from couchbase.cluster import *
+from couchbase_core.cluster import PasswordAuthenticator
+from couchbase_v2 import COMPRESS_INOUT
+#tag::connstr[]
+# Will set the compression type to inout
+Cluster.connect(
+    "127.0.0.1?compression=inout",ClusterOptions(PasswordAuthenticator(
+    "user",
+    "pass")))
+
+# This is equivalent to
+collection.compression = COMPRESS_INOUT
+#end::connstr[]
+
+#natag::rbac[]
+# add convenience overload when available
+Cluster.connect("127.0.0.1", PasswordAuthenticator("username", "password"))
+#naend::rbac[]
+
+#tag::rbac-full[]
+Cluster.connect(
+    "127.0.0.1",
+    ClusterOptions(PasswordAuthenticator("username", "password")))
+#end::rbac-full[]
+
+from couchbase_core.cluster import  CertAuthenticator
+import os
+#tag::certauth[]
+cert_dir=os.path.join(os.path.curdir,"cert_dir")
+
+Cluster.connect("127.0.0.1", ClusterOptions(
+    CertAuthenticator(cert_path="cert.pem",
+                      key_path="key.crt",
+                      trust_store_path="trust_store.pem"
+)))
+#end::certauth[]
+
+#tag::simpleget[]
+cluster = Cluster.connect("127.0.0.1", ClusterOptions(PasswordAuthenticator("user", "pass")))
+bucket = cluster.bucket("travel-sample")
+collection = bucket.default_collection()
+
+get_result = collection.get("airline_10")
+
+#end::simpleget[]
+
+cluster = Cluster.connect("127.0.0.1", ClusterOptions(PasswordAuthenticator("user", "pass")))
+bucket = cluster.bucket("travel-sample")
+collection = bucket.default_collection()
+
+# tag::upsertandget[]
+upsert_result = collection.upsert("mydoc-id", {})
+get_result = collection.get("mydoc-id")
+# end::upsertandget[]
+
+from couchbase_v2.bucket import Bucket
+
+# tag::upsertandget_sdk2[]
+# SDK 2 upsert and get
+bucket = Bucket("couchbases://127.0.0.1/default")
+upsert_result = bucket.upsert("mydoc-id", {})
+get_result = bucket.get("mydoc-id")
+# end::upsertandget_sdk2[]
+
+import couchbase_tests.base
+
+#natag::rawjson[]
+# TODO: update when implemented
+from couchbase.collection import UpsertOptions
+from couchbase_core.transcoder import Transcoder
+
+class RawJSONTranscoder(Transcoder):
+    pass
+
+content = "{}".encode("UTF_8")
+upsert_result = collection.upsert(
+    "mydoc-id",
+    content,
+    UpsertOptions(transcoder=RawJSONTranscoder))
+
+#naend::rawjson[]
+
+class TimeoutTest(couchbase_tests.base.CollectionTestCase):
+
+    def test_customtimeout(self):
+#tag::customtimeout[]
+# SDK 3 custom timeout
+        get_result = collection.get(
+            "mydoc-id",
+            GetOptions(timeout=timedelta(seconds=5)))
+        #tag::test[]
+        self.assertEquals("fish",get_result.content_as[str])
+        #end::test[]
+#end::customtimeout[]
+
+from couchbase_v2.bucket import Bucket
+bucket=Bucket("couchbase://127.0.0.1")
+#tag::querysimple_sdk2[]
+# SDK 2 simple query
+query_result = bucket.query("select * from `travel-sample` limit 10")
+for row in query_result:
+    value = row.value
+#end::querysimple_sdk2[]
+
+#tag::querysimple[]
+# SDK 3 simple query
+query_result = cluster.query("select * from `travel-sample` limit 10")
+for value in query_result:
+    #...
+    pass
+#end::querysimple[]
+
+from couchbase_v2.bucket import Bucket
+bucket=Bucket("couchbase://127.0.0.1")
+# tag::queryparameterized_sdk2[]
+# SDK 2 named parameters
+bucket.query(
+    "select * from bucket where type = $type",
+    type="airport")
+
+# SDK 2 positional parameters
+bucket.query(
+    "select * from bucket where type = $1",
+    "airport")
+
+del bucket
+
+# tag::queryparameterized[]
+# SDK 3 named parameters
+from couchbase.cluster import QueryOptions
+cluster.query(
+    "select * from bucket where type = $type",
+    QueryOptions(named_parameters={"type": "airport"}))
+
+# SDK 3 positional parameters
+cluster.query(
+    "select * from bucket where type = $1",
+    QueryOptions(positional_parameters=["airport"]))
+#end::queryparameterized[]
+
+#tag::analyticssimple[]
+# SDK 3 simple analytics query
+analytics_result = cluster.analytics_query("select * from dataset")
+for value in analytics_result:
+    #...
+    pass
+#end::analyticssimple[]
+
+#tag::analyticsparameterized[]
+from couchbase.cluster import AnalyticsOptions
+# SDK 3 named parameters for analytics
+cluster.analytics_query(
+        "select * from dataset where type = $type",
+        AnalyticsOptions(named_parameters={"type": 'airport'}))
+
+# SDK 3 positional parameters for analytics
+cluster.analytics_query(
+    "select * from dataset where type = $1",
+    AnalyticsOptions(positional_parameters=["airport"]))
+#end::analyticsparameterized[]
+
+
+#tag::analyticsparameterized_args_kwargs[]
+# SDK 3 named parameters for analytics
+# TODO: enable when implemented, still offering old style *args, **kwargs interface
+cluster.analytics_query(
+    "select * from dataset where type = $type",
+    type='airport')
+
+# SDK 3 positional parameters for analytics
+cluster.analytics_query(
+    "select * from dataset where type = $1",
+    ["airport"])
+#naend::analyticsparameterized_args_kwargs[]
+
+#tag::analyticsparameterized_args_kwargs[]
+
+# SDK 2 error check
+analyticsQueryResult = cluster.query("select * from foo")
+if not analyticsQueryResult.errors():
+    # errors contain [{"msg":"Cannot find dataset foo in dataverse Default nor an alias with name foo! (in line 1, at column 15)","code":24045}]
+    pass
+
+#tag::searchsimple[]
+# SDK 3 search query
+from couchbase.cluster import SearchOptions
+search_result = cluster.search_query(
+    "indexname",
+    "airports",
+    SearchOptions(timeout=timedelta(seconds=2),limit=5,fields=["a", "b", "c"]))
+for row in search_result:
+    # ...
+    pass
+#end::searchsimple[]
+
+from couchbase_core.fulltext import Facet, TermFacet, DateFacet, NumericFacet
+#natag::searchcheck_args_kwargs[]
+search_result = cluster.search_query(
+        "myindex",
+        facets={'searchstring':Facet(),queryString("searchstring")})#.)
+if search_result.metadata().error_count()==0:
+    # no errors present, so full data got returned
+    pass
+#naend::searchcheck_args_kwargs[]
+
+from couchbase.bucket import ViewOptions
+
+bucket=cluster.bucket("fred")
+#tag::viewquery[]
+# SDK 3 view query
+view_result = bucket.view_query(
+    "design",
+    "view",
+    ViewOptions(limit=5,skip=2,timeout=timedelta(seconds=10)))
+for row in view_result:
+    # ...
+    pass
+#end::viewquery[]

--- a/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
+++ b/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
@@ -90,8 +90,7 @@ Additionally these are supported optionally in SDK 2 and SDK 3.
 * **Twisted**
 * **gevent**
 
-
-If you are pulling in the SDK through a package manager (recommended), all mandatory dependencies will be resolved for you automatically.
+TIP: If you are pulling in the SDK through a package manager (recommended), all mandatory dependencies will be resolved for you automatically.
 
 
 
@@ -134,7 +133,7 @@ At the end of this guide you'll find a xref:#configurations-options-reference[re
 
 === Authentication
 
-Since SDK 2 supports Couchbase Server clusters older than 5.0, it had to support both Role-Based access control as well as bucket-level passwords.
+Since SDK 2 supports Couchbase Server clusters older than 5.0, it had to support both Role-Based Access Control (RBAC) as well as bucket-level passwords.
 The minimum cluster version supported by SDK 3 is Server 5.0, which means that only RBAC is supported.
 This is why you can set the username and password when directly connecting:
 

--- a/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
+++ b/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
@@ -59,10 +59,9 @@ include::6.5@sdk:shared:partial$migration.adoc[tag=lang]
 
 ===  Installation and Configuration
 
- - where to get the new artifacts / vs old place
-
 The Python SDK 3.x is available for download from the same resources as the previous generation. Builds can be found on PyPi.
 Please see the xref:sdk-release-notes.adoc[Release Notes] for up-to-date information.
+
 
  - discuss new dependencies if needed
  - discuss configuration old and new, especially if certain
@@ -167,11 +166,12 @@ Please see the xref:howtos:authentication.adoc[documentation on certificate-base
 
 == Connection Lifecycle
 
-- discuss bootstrapping
-- important: bootstrapping is now "lazy" so also discuss how to do the eager
-checks and any impact it might have on the first op being slow?
+// - discuss bootstrapping
+//- important: bootstrapping is now "lazy" so also discuss how to do the eager
+// checks and any impact it might have on the first op being slow?
 
 From a high-level perspective, bootstrapping and shutdown is very similar to SDK 2.
+////
 One notable difference is that the `Collection` is introduced and that the individual methods like `bucket` immediately return, and do not throw an exception.
 Compare SDK 2: the `openBucket` method would not work if it could not open the bucket.
 
@@ -208,22 +208,23 @@ Here is the SDK 3 equivalent:
 ----
 include::example$migrating.py[tag=simpleget,indent=0]
 ----
-
+////
 `Collections` will be generally available with an upcoming Couchbase Server release, but the SDK already encodes it in its API to be future-proof.
 If you are using a Couchbase Server version which does not support `Collections`, always use the `default_collection()` method to access the KV API; it will map to the full bucket.
 
+////
 IMPORTANT: You'll notice that `bucket(str)` returns immediately, even if the bucket resources are not completely opened.
 This means that the subsequent `get` operation may be dispatched even before the socket is open in the background.
 The SDK will handle this case transparently, and reschedule the operation until the bucket is opened properly.
 This also means that if a bucket could not be opened (say, because no server was reachable) the operation will time out.
 Please check the logs to see the cause of the timeout (in this case, you'll see socket connect rejections).
-
+////
 Also note, you will now find Query, Search, and Analytics at the `Cluster` level.
 This is where they logically belong.
 If you are using Couchbase Server 6.5 or later, you will be able to perform cluster-level queries even if no bucket is open.
 If you are using an earlier version of the cluster you must open at least one bucket, otherwise cluster-level queries will fail.
 
-
+////
 === Serialization and Transcoding
 
  - describe how it works for your language, how to override and any platform-specific
@@ -263,13 +264,13 @@ While a transcoder can handle many different storage types, the serializer is sp
 On all JSON-only APIs (i.e. Sub-doc, Query, Search,...) you'll only find a `Serializer`, not a `Transcoder`, in the operation options.
 Usually there is no need to override it unless you want to provide your own implementation (i.e. if you have your own POJO mapping json logic in place, and want to reuse it).
 
-
+////
 == Exception Handling
 
-- discuss new exception hierarchy in principle and how users should
-approach it when migrating
-- explain maybe new error handling strategies that are in place,
-around retry strategies especially and their behavior
+//- discuss new exception hierarchy in principle and how users should
+//approach it when migrating
+//- explain maybe new error handling strategies that are in place,
+// around retry strategies especially and their behavior
 
 How to _handle_ exceptions is unchanged from SDK 2.
 You should still use `try/catch` on the blocking APIs and the corresponding async methods on the other APIs.
@@ -278,13 +279,12 @@ There have been changes made in the following areas:
 - Exception hierarchy and naming.
 - Proactive retry where possible.
 
-
 === Exception Hierarchy
 
 The exception hierarchy is now unified under a `CouchbaseException`.
 // TODO: update after ErrorContexts exposed
 //Each `CouchbaseException` has an associated `ErrorContext` which is populated with as much info as possible and then dumped alongside the stack trace if an error happens.
-
+////
 Here is an example of the error context if a N1QL query is performed with an invalid syntax (i.e. `select 1= from`):
 
 [source]
@@ -307,7 +307,9 @@ As an example, consider the javadoc for the `Collection.get` API:
 ----
 
 These exceptions extend `CouchbaseException`, but both the `TimeoutException` and the `DocumentNotFoundException` can be caught individually if specific logic should be executed to handle them.
+////
 
+////
 === Proactive Retry
 
 One reason why the APIs do not expose a long list of exceptions is that the SDK now retries as many operations as it can if it can do so safely.
@@ -323,7 +325,9 @@ When migrating your SDK 2 exception handling code to SDK 3, make sure to wrap ev
 You can likely remove your user-level retry code for temporary failures, backpressure exception, and so on.
 One notable exception from this is the `CasMismatchException`, which is still thrown since it requires more app-level code to handle (most likely identical to SDK 2).
 
+////
 
+////
 === Logging and Events
 
  - discuss any changes to the logging infrastructure or event system if made
@@ -353,13 +357,11 @@ Please see xref:howtos:collecting-information-and-logging.adoc[the logging docum
    and discusses old vs. new
 
 The following section discusses each service in detail and covers specific bits that have not been covered by the more generic sections above.
+////
 
-==== Key Value
+== Key Value
 
- - don't forget the get replica changes!
-
-
-The Key/Value (KV) API is now located under the `Collection` interface, so even if you do not use collections, the `defaultCollection()` needs to be opened in order to access it.
+The Key/Value (KV) API is now located under the `Collection` interface, so even if you do not use collections, the `default_collection()` call needs to be opened in order to access it.
 
 The following table describes the SDK 2 KV APIs and where they are now located in SDK 3:
 
@@ -370,7 +372,7 @@ The following table describes the SDK 2 KV APIs and where they are now located i
 |`Bucket.upsert`          |`Collection.upsert`
 |`Bucket.get`             |`Collection.get`
 |`Bucket.exists`          |`Collection.exists`
-|`Bucket.get_from_replica`|`Collection.get_any_replica`and_`collection_get_all_replicas`
+|`Bucket.get_from_replica`|`Collection.get_any_replica` and `collection_get_all_replicas`
 |`Bucket.get_and_lock`    |`Collection.get_and_lock`
 |`Bucket.get_and_touch`   |`Collection.get_and_touch`
 |`Bucket.insert`          |`Collection.insert`
@@ -392,22 +394,22 @@ In addition, the datastructure APIs have been renamed and moved:
 [options="header"]
 |====
 | SDK 2                          | SDK 3
-|`Bucket.mapAdd`                 | `Collection.map`
-|`Bucket.mapGet`                 | `Collection.map`
-|`Bucket.mapRemove`              | `Collection.map`
-|`Bucket.mapSize`                | `Collection.map`
-|`Bucket.listGet`                | `Collection.list`
-|`Bucket.listAppend`             | `Collection.list`
-|`Bucket.listRemove`             | `Collection.list`
-|`Bucket.listPrepend`            | `Collection.list`
-|`Bucket.listSet`                | `Collection.list`
-|`Bucket.listSize`               | `Collection.list`
-|`Bucket.setAdd`                 | `Collection.set`
-|`Bucket.setContains`            | `Collection.set`
-|`Bucket.setRemove`              | `Collection.set`
-|`Bucket.setSize`                | `Collection.set`
-|`Bucket.queuePush`              | `Collection.queue`
-|`Bucket.queuePop`               | `Collection.queue`
+|`Bucket.mapAdd`                 | `Collection.map_add`
+|`Bucket.mapGet`                 | `Collection.map_get`
+|`Bucket.mapRemove`              | `Collection.map_remove`
+|`Bucket.mapSize`                | `Collection.map_size`
+|`Bucket.listGet`                | `Collection.list_get`
+|`Bucket.listAppend`             | `Collection.list_append`
+|`Bucket.listRemove`             | `Collection.list_remove`
+|`Bucket.listPrepend`            | `Collection.list_prepend`
+|`Bucket.listSet`                | `Collection.list_set`
+|`Bucket.listSize`               | `Collection.list_size`
+|`Bucket.setAdd`                 | `Collection.set_add`
+|`Bucket.setContains`            | `Collection.set_contains`
+|`Bucket.setRemove`              | `Collection.set_remove`
+|`Bucket.setSize`                | `Collection.set_size`
+|`Bucket.queuePush`              | `Collection.queue_push`
+|`Bucket.queuePop`               | `Collection.queue_pop`
 |====
 
 There are two important API changes:
@@ -416,13 +418,17 @@ There are two important API changes:
 * On the response side, the return types have been unified.
 
 The signatures now look very similar.
+////
 The concept of the `Document` as a type is gone in SDK 3 and instead you need to pass in the properties explicitly.
 This makes it very clear what is returned, especially on the response side.
+////
+In SKD3, the `get` method returns a `GetResult`, and the `upsert` does returns `MutationResult`.
 
-Thus, the `get` method does not return a `Document` but a `GetResult` instead, and the `upsert` does not return a `Document` but a `MutationResult`.
-Each of those results only contains the field that the specific method can actually return, making it impossible to accidentally try to access the `expiry` on the `Document` after a mutation, for example.
+Each of those results only contains the fields that the specific method can actually return, making it impossible to accidentally try to access the `expiry` on the `Result` after a mutation, for example.
 
-Instead of having many overloads, all optional params are now part of the `Option` block.
+Optional parameters are now accessible via `couchbase.options.OptionBlock` derivatives, or via named parameters (with the latter overriding
+the former).
+
 All required params are still part of the method signature, making it clear what is required and what is not (or has default values applied if not overridden).
 
 The timeout can be overridden on every operation and now takes a `datetime.timedelta` object from the Python standard library.
@@ -478,55 +484,24 @@ include::example$migrating.py[tag=queryparameterized_sdk2,indent=0]
 ----
 include::example$migrating.py[tag=queryparameterized,indent=0]
 ----
-
+////
 If you want to use prepared statements, the `adhoc()` method is still available on the `QueryOptions`, alongside every other option that used to be exposed on the SDK 2 Query options.
 
 Much of the non-row metadata has been moved into a specific `QueryMetaData` section:
-
 .Query Metadata Changes
 [options="header"]
 |====
-| SDK 2                             | SDK 3
-|`N1qlQueryResult.signature`        | `QueryResult.metaData.signature`
-|`N1qlQueryResult.info`             | `QueryResult.metaData.metrics`
-|`N1qlQueryResult.profileInfo`      | `QueryResult.metaData.profile`
-|`N1qlQueryResult.parseSuccess`     | removed
-|`N1qlQueryResult.finalSuccess`     | removed
-|`N1qlQueryResult.status`           | `QueryResult.metaData.status`
-|`N1qlQueryResult.errors`           | throws an Exception on `QueryResult`
-|`N1qlQueryResult.requestId`        | `QueryResult.metaData.requestId`
-|`N1qlQueryResult.clientContextId`  | `QueryResult.metaData.clientContextId`
+| SDK 2                     | SDK 3
+|`N1QLRequest.metrics`      | `QueryResult.metrics`
+|`N1QLRequest.profile`      | `QueryResult.profile`
+
 |====
+////
 
-It is no longer necessary to check for a specific error in the stream: if an error happened during processing it will throw an exception at the top level of the query.
-The reactive streaming API will terminate the rows' `Flux` with an exception as well as soon as it is discovered.
-This makes error handling much easier in both the blocking and non-blocking cases.
 
-While in SDK 2 you had to manually check for errors (otherwise you'd get an empty row collection):
+==== Analytics
 
-[source,python]
-
-----
-N1qlQueryResult queryResult = bucket.query(N1qlQuery.simple("select 1="));
-if (!queryResult.errors().isEmpty()) {
-  // errors contain [{"msg":"syntax error - at end of input","code":3000}]
-}
-----
-
-In SDK 3 the top level `query` method will throw an exception:
-
-[source]
-----
-Exception in thread "main" com.couchbase.client.core.error.ParsingFailedException: Parsing of the input failed {"completed":true,"coreId":1,"errors":[{"code":3000,"message":"syntax error - at end of input"}],"idempotent":false,"lastDispatchedFrom":"127.0.0.1:51703","lastDispatchedTo":"127.0.0.1:8093","requestId":5,"requestType":"QueryRequest","retried":0,"service":{"operationId":"1c623a77-196a-4890-96cd-9d4f3f596477","statement":"select 1=","type":"query"},"timeoutMs":75000,"timings":{"dispatchMicros":13798,"totalMicros":70789}}
-	at com.couchbase.client.java.AsyncUtils.block(AsyncUtils.java:51)
-	at com.couchbase.client.java.Cluster.query(Cluster.java:225)
-----
-
-Not only does it throw a `CouchbaseException`, it also tries to map it to a specific exception type and include extensive contextual information for a better troubleshooting experience.
-
-=== Analytics
-
-Analytics querying, like N1QL, is also moved to the `Cluster` level: it is now accessible through the `Cluster.analyticsQuery` method.
+Analytics querying, like N1QL, is also moved to the `Cluster` level: it is now accessible through the `Cluster.analytics_query` method.
 As with the Query service, parameters for the Analytics queries have moved into the `AnalyticsOptions`:
 
 [source,python]
@@ -540,7 +515,7 @@ include::example$migrating.py[tag=analyticssimple,indent=0]
 ----
 include::example$migrating.py[tag=analyticsparameterized,indent=0]
 ----
-
+////
 Also, errors will now be thrown as top level exceptions and it is no longer necessary to explicitly check for errors:
 
 [source,python]
@@ -557,7 +532,9 @@ com.couchbase.client.core.error.DatasetNotFoundException: The analytics dataset 
 	at com.couchbase.client.java.AsyncUtils.block(AsyncUtils.java:51)
 	at com.couchbase.client.java.Cluster.analyticsQuery(Cluster.java:250)
 ----
+////
 
+////
 === Search
 
 The Search API has changed a bit in SDK 3 so that it aligns with the other query APIs.
@@ -569,8 +546,11 @@ Here is a SDK 2 Search query with some options, and its SDK 3 equivalent:
 [source,python]
 
 ----
-//  SDK 2 search query
-SearchQueryResult searchResult = bucket.query(new SearchQuery(
+# SDK 2 search query
+from couchbase_v2.cluster import Cluster, PasswordAuthenticator
+cluster=Cluster("couchbase://127.0.0.1","default","password")
+bucket=cluster.open_bucket("default")
+search_result = bucket.query(new SearchQuery(
   "indexname",
   SearchQuery.queryString("airports")).limit(5).fields("a", "b", "c"),
   2,
@@ -607,7 +587,9 @@ If you want to be absolutely sure that you didn't get only partial data, you can
 ----
 include::example$migrating.py[tag=searchcheck,indent=0]
 ----
+////
 
+////
 === Views
 
 Views have stayed at the `Bucket` level, because it does not have the concept of collections and is scoped at the bucket level on the server as well.
@@ -654,15 +636,17 @@ com.couchbase.client.core.error.ViewNotFoundException: The queried view is not f
 
 ----
 
+////
+
 == Management APIs
 
- - discusses how to migrate from each old management api to the new one
- - where it is found, what exceptions it throws, etc.
+//// - discusses how to migrate from each old management api to the new one
+//// - where it is found, what exceptions it throws, etc.
 
 
 In SDK 2, the management APIs were centralized in the `Admin` class at the cluster level and the `BucketManager` class at the bucket level.
 Since SDK 3 provides more management APIs, they have been split up in their respective domains.
-So for example when in SDK 2 you needed to remove a bucket you would call `ClusterManager.removeBucket` you will now find it under `BucketManager.dropBucket`.
+So for example when in SDK 2 you needed to remove a bucket you would call `Admin.bucket_remove` you will now find it under `BucketManager.drop_bucket`.
 Also, creating a N1QL index now lives in the `QueryIndexManager`, which is accessible through the `Cluster`.
 
 The following table provides a mapping from the SDK 2 management APIs to those of SDK 3:
@@ -700,6 +684,7 @@ The following table provides a mapping from the SDK 2 management APIs to those o
 | `BucketManager.n1ql_index_watch`           | `QueryIndexManager.watch_indexes`
 |====
 
+////
 Extra Java stuff to be ported if possible
 
 
@@ -825,3 +810,4 @@ Note that some options have been removed, and others have different ways to conf
 |`propagateParentSpan`         | removed
 |====
 
+////

--- a/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
+++ b/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
@@ -62,7 +62,7 @@ include::6.5@sdk:shared:partial$migration.adoc[tag=lang]
 The Python SDK 3.x is available for download from the same resources as the previous generation. Builds can be found on PyPi.
 Please see the xref:sdk-release-notes.adoc[Release Notes] for up-to-date information.
 
-
+////
  - discuss new dependencies if needed
  - discuss configuration old and new, especially if certain
    custom options are not present anymore (why they are not used)
@@ -70,7 +70,7 @@ Please see the xref:sdk-release-notes.adoc[Release Notes] for up-to-date informa
    new one
  - discuss cert auth
  - discuss encryption config
-
+////
 IMPORTANT: Python SDK 3.x has a minimum required Python version of 3.0, although we recommend running the latest version (i.e. at the time of writing Python 3.8) with the highest patch version available.
 
 Note that the transitive dependency list has changed.
@@ -383,9 +383,11 @@ The following table describes the SDK 2 KV APIs and where they are now located i
 |`Bucket.touch`           |`Collection.touch`
 |`Bucket.lookup_in`       |`Collection.lookup_in`
 |`Bucket.mutate_in`       |`Collection.mutate_in`
+////
 |`Bucket.counter`         |`BinaryCollection.increment` and `BinaryCollection.decrement`
 |`Bucket.append`          |`BinaryCollection.append`
 |`Bucket.prepend`         |`BinaryCollection.prepend`
+////
 |====
 
 In addition, the datastructure APIs have been renamed and moved:
@@ -422,7 +424,7 @@ The signatures now look very similar.
 The concept of the `Document` as a type is gone in SDK 3 and instead you need to pass in the properties explicitly.
 This makes it very clear what is returned, especially on the response side.
 ////
-In SKD3, the `get` method returns a `GetResult`, and the `upsert` does returns `MutationResult`.
+In SDK3, the `get` method returns a `GetResult`, and the `upsert` returns `MutationResult`.
 
 Each of those results only contains the fields that the specific method can actually return, making it impossible to accidentally try to access the `expiry` on the `Result` after a mutation, for example.
 
@@ -441,18 +443,18 @@ include::example$migrating.py[tag=customtimeout,indent=0]
 
 In SDK 2, the `get_from_replica` method had a `ReplicaMode` argument which allowed to customize its behavior on how many replicas should be reached.
 We have identified this as a potential source of confusion and as a result split it up in two methods that simplify usage significantly.
-There is now a `getAllReplicas` method and a `getAnyReplica` method.
+There is now a `get_all_replicas` method and a `get_any_replica` method.
 
 * `get_all_replicas` asks the active node and all available replicas and returns the results as a stream.
 * `get_any_replica` uses `get_all_replicas`, and returns the first result obtained.
 
 Unless you want to build some kind of consensus between the different replica responses, we recommend `get_any_replica` for a fallback to a regular `get` when the active node times out.
-
+////
 NOTE: Operations which cannot be performed on JSON documents have been moved to the `BinaryCollection`, accessible through `Collection.binary()`.
 These operations include `append`, `prepend`, `increment`, and `decrement` (previously called `counter` in SDK 2).
 These operations should only be used against non-json data.
 Similar functionality is available through `mutateIn` on JSON documents.
-
+////
 === Query
 
 N1QL querying is now available at the `Cluster` level instead of the bucket level, because you can also write N1QL queries that span multiple buckets. Compare a simple N1QL query from SDK 2 with its SDK 3 equivalent:
@@ -469,7 +471,6 @@ include::example$migrating.py[tag=querysimple_sdk2,indent=0]
 include::example$migrating.py[tag=querysimple,indent=0]
 ----
 
-Note that there is no `N1qlQuery.simple` any more -- parameter option have been moved to the `queryOptions()` for consistency reasons.
 The following shows how to do named and positional parameters in SDK 2, and their SDK 3 counterparts:
 
 [source,python]
@@ -640,8 +641,8 @@ com.couchbase.client.core.error.ViewNotFoundException: The queried view is not f
 
 == Management APIs
 
-//// - discusses how to migrate from each old management api to the new one
-//// - where it is found, what exceptions it throws, etc.
+// - discusses how to migrate from each old management api to the new one
+// - where it is found, what exceptions it throws, etc.
 
 
 In SDK 2, the management APIs were centralized in the `Admin` class at the cluster level and the `BucketManager` class at the bucket level.

--- a/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
+++ b/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
@@ -396,22 +396,22 @@ In addition, the datastructure APIs have been renamed and moved:
 [options="header"]
 |====
 | SDK 2                          | SDK 3
-|`Bucket.mapAdd`                 | `Collection.map_add`
-|`Bucket.mapGet`                 | `Collection.map_get`
-|`Bucket.mapRemove`              | `Collection.map_remove`
-|`Bucket.mapSize`                | `Collection.map_size`
-|`Bucket.listGet`                | `Collection.list_get`
-|`Bucket.listAppend`             | `Collection.list_append`
-|`Bucket.listRemove`             | `Collection.list_remove`
-|`Bucket.listPrepend`            | `Collection.list_prepend`
-|`Bucket.listSet`                | `Collection.list_set`
-|`Bucket.listSize`               | `Collection.list_size`
-|`Bucket.setAdd`                 | `Collection.set_add`
-|`Bucket.setContains`            | `Collection.set_contains`
-|`Bucket.setRemove`              | `Collection.set_remove`
-|`Bucket.setSize`                | `Collection.set_size`
-|`Bucket.queuePush`              | `Collection.queue_push`
-|`Bucket.queuePop`               | `Collection.queue_pop`
+|`Bucket.map_add`                 | `Collection.map_add`
+|`Bucket.map_get`                 | `Collection.map_get`
+|`Bucket.map_remove`              | `Collection.map_remove`
+|`Bucket.map_size`                | `Collection.map_size`
+|`Bucket.list_get`                | `Collection.list_get`
+|`Bucket.list_append`             | `Collection.list_append`
+|`Bucket.list_remove`             | `Collection.list_remove`
+|`Bucket.list_prepend`            | `Collection.list_prepend`
+|`Bucket.list_set`                | `Collection.list_set`
+|`Bucket.list_size`               | `Collection.list_size`
+|`Bucket.set_add`                 | `Collection.set_add`
+|`Bucket.set_contains`            | `Collection.set_contains`
+|`Bucket.set_remove`              | `Collection.set_remove`
+|`Bucket.set_size`                | `Collection.set_size`
+|`Bucket.queue_push`              | `Collection.queue_push`
+|`Bucket.queue_pop`               | `Collection.queue_pop`
 |====
 
 There are two important API changes:

--- a/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
+++ b/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
@@ -21,18 +21,23 @@ include::6.5@sdk:shared:partial$migration.adoc[tag=terms]
 
 As an example here is a KeyValue document fetch:
 
-// change to $Your_language
-[source,java]
+[source,python]
 ----
-GetResult getResult = collection.get("key", getOptions().timeout(Duration.ofSeconds(3));
+
+from datetime import timedelta
+from couchbase.cluster import Cluster
+from couchbase.collection import GetOptions
+cluster=Cluster("couchbases://10.192.1.104")
+collection=cluster.default_collection()
+get_result = collection.get("key", GetOptions(timeout=timedelta(seconds=3)))
 ----
 
 Compare this to a N1QL query:
 
 // change to $Your_language
-[source,java]
+[source,python]
 ----
-QueryResult queryResult = cluster.query("select 1=1", queryOptions().timeout(Duration.ofSeconds(3));
+query_result = cluster.query("select 1=1", QueryOptions(timeout=timedelta(seconds=3))
 ----
 
 include::6.5@sdk:shared:partial$migration.adoc[tag=terms2]
@@ -45,6 +50,7 @@ include::6.5@sdk:shared:partial$migration.adoc[tag=lang]
 
 
 
+
 // Outline below for individual SDKs -- please expand as appropriate, many topics can be covered lightly
 //
 // Please use before(2.n) / after (3.0) snippets in all cases where it is helpful
@@ -54,6 +60,10 @@ include::6.5@sdk:shared:partial$migration.adoc[tag=lang]
 ===  Installation and Configuration
 
  - where to get the new artifacts / vs old place
+
+The Python SDK 3.x is available for download from the same resources as the previous generation. Builds can be found on PyPi.
+Please see the xref:sdk-release-notes.adoc[Release Notes] for up-to-date information.
+
  - discuss new dependencies if needed
  - discuss configuration old and new, especially if certain
    custom options are not present anymore (why they are not used)
@@ -62,59 +72,756 @@ include::6.5@sdk:shared:partial$migration.adoc[tag=lang]
  - discuss cert auth
  - discuss encryption config
 
-===  Connection Lifecycle
+IMPORTANT: Python SDK 3.x has a minimum required Python version of 3.0, although we recommend running the latest version (i.e. at the time of writing Python 3.8) with the highest patch version available.
 
- - discuss bootstrapping
- - important: bootstrapping is now "lazy" so also discuss how to do the eager
-   checks and any impact it might have on the first op being slow?
- - discuss shutdown
- - if external state is passed in optionally, discuss
-   management of this state
- - discuss the impact of 6.5 "gcccp" and cluster level queries
- - SASL by default on non-PLAIN (if applicable)
+Note that the transitive dependency list has changed.
+As a refresher, Python SDK 2 depended on the following packages:
 
-===  Exception Handling
+* **typing**
 
- - discuss new exception hierachy in principle and how users should
-   approach it when migrating
- - explain maybe new error handling strategies that are in place,
-   around retry strategies especially and their behavior
+SDK 3 depends on the following ones instead:
+
+* **typing** (on Python<3.7)
+* **typing-extensions** (on Python<3.8)
+* **boltons**
+* **pyrsistent**
+
+Additionally these are supported optionally in SDK 2 and SDK 3.
+
+* **Twisted**
+* **gevent**
+
+
+If you are pulling in the SDK through a package manager (recommended), all mandatory dependencies will be resolved for you automatically.
+
+
+
+=== Configuring Collections
+
+The fundamental semantics of the `Bucket` from SDK 2 are analogous to that of the `Collection` in SDK 3.
+
+[source,python]
+----
+# SDK 2 custom KV timeout
+bucket = Bucket("couchbases://127.0.0.1/default")
+bucket.timeout=5
+----
+
+[source,python]
+
+----
+include::example$migrating.py[tag=timeoutbuilder,indent=0]
+----
+
+The default settings can still be customized through either the connection string or xref:ref:client-settings.adoc[system properties].
+The SDK has elaborate reflection logic in place to parse "flat" string values and apply them to the builder, which means that you can now configure more properties than in SDK 2.
+Note that the property paths have changed.
+
+[source,python]
+
+----
+include::example$migrating.py[tag=sysprops,indent=0]
+----
+
+[source,python]
+
+----
+include::example$migrating.py[tag=connstr,indent=0]
+----
+See the xref:ref:client-settings.adoc[configuration section] for full specifics.
+
+At the end of this guide you'll find a xref:#configurations-options-reference[reference] that describes the SDK 2 environment options and their SDK 3 equivalents where applicable.
+
+
+=== Authentication
+
+Since SDK 2 supports Couchbase Server clusters older than 5.0, it had to support both Role-Based access control as well as bucket-level passwords.
+The minimum cluster version supported by SDK 3 is Server 5.0, which means that only RBAC is supported.
+This is why you can set the username and password when directly connecting:
+
+[source,python]
+
+----
+include::example$migrating.py[tag=rbac,indent=0]
+----
+
+This is just a shorthand for:
+
+[source,python]
+
+----
+include::example$migrating.py[tag=rbac-full,indent=0]
+----
+
+The reason why you can pass in a specific authenticator is that you can also use the same approach to configure certificate-based authentication:
+
+
+[source,python]
+
+----
+include::example$migrating.py[tag=certauth,indent=0]
+----
+
+Please see the xref:howtos:authentication.adoc[documentation on certificate-based authentication] for detailed information on how to configure this properly.
+
+
+== Connection Lifecycle
+
+- discuss bootstrapping
+- important: bootstrapping is now "lazy" so also discuss how to do the eager
+checks and any impact it might have on the first op being slow?
+
+From a high-level perspective, bootstrapping and shutdown is very similar to SDK 2.
+One notable difference is that the `Collection` is introduced and that the individual methods like `bucket` immediately return, and do not throw an exception.
+Compare SDK 2: the `openBucket` method would not work if it could not open the bucket.
+
+The reason behind this change is that even if a bucket can be opened, a millisecond later it may not be available any more.
+All this state has been moved into the actual operation so there is only a single place where the error handling needs to take place.
+This simplifies error handling and retry logic for an application.
+
+- discuss shutdown
+- if external state is passed in optionally, discuss
+management of this state
+- discuss the impact of 6.5 "gcccp" and cluster level queries
+- SASL by default on non-PLAIN (if applicable)
+
+
+
+In SDK 2, you connected, opened a bucket and performed a KV op like this:
+
+[source,python]
+
+----
+from couchbase_v2.cluster import Cluster as SDK2Cluster, PasswordAuthenticator
+cluster = SDK2Cluster("127.0.0.1")
+cluster.authenticate(PasswordAuthenticator("user", "pass"))
+bucket = cluster.open_bucket("travel-sample")
+
+get_result = bucket.get("airline_10")
+
+----
+
+Here is the SDK 3 equivalent:
+
+[source,python]
+
+----
+include::example$migrating.py[tag=simpleget,indent=0]
+----
+
+`Collections` will be generally available with an upcoming Couchbase Server release, but the SDK already encodes it in its API to be future-proof.
+If you are using a Couchbase Server version which does not support `Collections`, always use the `default_collection()` method to access the KV API; it will map to the full bucket.
+
+IMPORTANT: You'll notice that `bucket(str)` returns immediately, even if the bucket resources are not completely opened.
+This means that the subsequent `get` operation may be dispatched even before the socket is open in the background.
+The SDK will handle this case transparently, and reschedule the operation until the bucket is opened properly.
+This also means that if a bucket could not be opened (say, because no server was reachable) the operation will time out.
+Please check the logs to see the cause of the timeout (in this case, you'll see socket connect rejections).
+
+Also note, you will now find Query, Search, and Analytics at the `Cluster` level.
+This is where they logically belong.
+If you are using Couchbase Server 6.5 or later, you will be able to perform cluster-level queries even if no bucket is open.
+If you are using an earlier version of the cluster you must open at least one bucket, otherwise cluster-level queries will fail.
+
 
 === Serialization and Transcoding
 
  - describe how it works for your language, how to override and any platform-specific
-   encoding and decoding guidelines. 
+   encoding and decoding guidelines.
  - Also important how to convert from the document types to the new approach
+
+In SDK 2 the main method to control transcoding was through providing different `Document` instances (which in turn had their own transcoder associated), such as the `JsonDocument`.
+This only worked for the KV APIs though -- Query, Search, Views, and other services exposed their JSON rows/hits in different ways.
+All of this has been unified in SDK 3 under a single concept: serializers and transcoders.
+
+By default, all KV APIs transcode to and from JSON -- you can also provide Python Transcodable objects which you couldn't in the past.
+
+[source,python]
+
+----
+include::example$migrating.py[tag=upsertandget_sdk2,indent=0]
+----
+
+[source,python]
+
+----
+include::example$migrating.py[tag=upsertandget,indent=0]
+----
+
+
+//[source,python]
+//
+//----
+//include::example$migrating.py[tag=rawjson,indent=0]
+//----
+
+
+Serializers and transcoders can also be customized and overwritten on a per-operation basis, please see the appropriate documentation section for details.
+
+The JSON `Transcoders` use a `Serializer` underneath.
+While a transcoder can handle many different storage types, the serializer is specialized for JSON encoding and decoding.
+On all JSON-only APIs (i.e. Sub-doc, Query, Search,...) you'll only find a `Serializer`, not a `Transcoder`, in the operation options.
+Usually there is no need to override it unless you want to provide your own implementation (i.e. if you have your own POJO mapping json logic in place, and want to reuse it).
+
+
+== Exception Handling
+
+- discuss new exception hierarchy in principle and how users should
+approach it when migrating
+- explain maybe new error handling strategies that are in place,
+around retry strategies especially and their behavior
+
+How to _handle_ exceptions is unchanged from SDK 2.
+You should still use `try/catch` on the blocking APIs and the corresponding async methods on the other APIs.
+There have been changes made in the following areas:
+
+- Exception hierarchy and naming.
+- Proactive retry where possible.
+
+
+=== Exception Hierarchy
+
+The exception hierarchy is now unified under a `CouchbaseException`.
+// TODO: update after ErrorContexts exposed
+//Each `CouchbaseException` has an associated `ErrorContext` which is populated with as much info as possible and then dumped alongside the stack trace if an error happens.
+
+Here is an example of the error context if a N1QL query is performed with an invalid syntax (i.e. `select 1= from`):
+
+[source]
+----
+Exception in thread "main" com.couchbase.client.core.error.ParsingFailedException: Parsing of the input failed {"completed":true,"coreId":1,"errors":[{"code":3000,"message":"syntax error - at from"}],"idempotent":false,"lastDispatchedFrom":"127.0.0.1:62253","lastDispatchedTo":"127.0.0.1:8093","requestId":3,"requestType":"QueryRequest","retried":11,"retryReasons":["ENDPOINT_TEMPORARILY_NOT_AVAILABLE","BUCKET_OPEN_IN_PROGRESS"],"service":{"operationId":"9111b961-e585-42f2-9cab-e1501da7a40b","statement":"select 1= from","type":"query"},"timeoutMs":75000,"timings":{"dispatchMicros":15599,"totalMicros":1641134}}
+----
+
+The expectation is that the application catches the `CouchbaseException` and deals with it as an unexpected error
+(e.g. logging with subsequent bubbling up of the exception or failing).
+In addition to that, each method exposes exceptions that can be caught separately if needed.
+As an example, consider the javadoc for the `Collection.get` API:
+
+[source]
+----
+...
+   * @throws DocumentNotFoundException the given document id is not found in the collection.
+   * @throws TimeoutException if the operation times out before getting a result.
+   * @throws CouchbaseException for all other error reasons (acts as a base type and catch-all).
+...
+----
+
+These exceptions extend `CouchbaseException`, but both the `TimeoutException` and the `DocumentNotFoundException` can be caught individually if specific logic should be executed to handle them.
+
+=== Proactive Retry
+
+One reason why the APIs do not expose a long list of exceptions is that the SDK now retries as many operations as it can if it can do so safely.
+This depends on the type of operation (idempotent or not), in which state of processing it is (already dispatched or not), and what the actual response code is if it arrived already.
+As a result, many transient cases -- such as locked documents, or temporary failure -- are now retried by default and should less often impact applications.
+It also means, when migrating to the new SDK API, you may observe a longer period of time until an error is returned by default.
+
+NOTE: Operations are retried by default as described above with the default `BestEffortRetryStrategy`.
+Like in SDK 2 you can configure fail-fast retry strategies to not retry certain or all operations.
+The `RetryStrategy` interface has been extended heavily in SDK 3 -- please see the xref:howtos:error-handling.adoc[error handling documentation].
+
+When migrating your SDK 2 exception handling code to SDK 3, make sure to wrap every call with a catch for `CouchbaseException` (or let it bubble up immediately).
+You can likely remove your user-level retry code for temporary failures, backpressure exception, and so on.
+One notable exception from this is the `CasMismatchException`, which is still thrown since it requires more app-level code to handle (most likely identical to SDK 2).
+
 
 === Logging and Events
 
  - discuss any changes to the logging infrastructure or event system if made
 
+
+Configuring and consuming logs has not greatly changed.
+The SDK still uses _SLF4J_, if found on the classpath, and if not reverts back to the JDK logger (it can also be configured to log to `stderr` instead).
+The big difference is that the `EventBus` (also present in SDK 2) has been made much more powerful -- and all logs are sent as events through it.
+The `LoggingEventConsumer` being one of the potential consumers, and turning events into log lines.
+
+The biggest impact you'll see from it is that the log messages now look very structured and contain contextual information where possible.
+
+[source]
+----
+13:36:46 INFO  [com.couchbase.node:470] [com.couchbase.node][NodeConnectedEvent] Node connected {"coreId":1,"managerPort":"8091","remote":"127.0.0.1"}
+13:36:46 INFO  [com.couchbase.core:470] [com.couchbase.core][BucketOpenedEvent][393161µs] Opened bucket "travel-sample" {"coreId":1}
+----
+
+Notice the package path (which you can also filter on if needed), the event name, an optional time that it took to perform the operation, the message and surrounding context.
+This makes it easier to debug potential problems but also allows consuming all the events and feeding them in other monitoring systems without having to round-trip a file log.
+Please see xref:howtos:collecting-information-and-logging.adoc[the logging documentation] for further information.
+
+
 ===  Migrating Services
 
- - one section for each service that goes in-depth on each command 
+ - one section for each service that goes in-depth on each command
    and discusses old vs. new
+
+The following section discusses each service in detail and covers specific bits that have not been covered by the more generic sections above.
 
 ==== Key Value
 
  - don't forget the get replica changes!
 
-==== Query
 
-==== Analytics
+The Key/Value (KV) API is now located under the `Collection` interface, so even if you do not use collections, the `defaultCollection()` needs to be opened in order to access it.
+
+The following table describes the SDK 2 KV APIs and where they are now located in SDK 3:
+
+.SDK 2.x KV API vs. SDK 3.x KV API
+[options="header"]
+|====
+|SDK 2                    |SDK 3
+|`Bucket.upsert`          |`Collection.upsert`
+|`Bucket.get`             |`Collection.get`
+|`Bucket.exists`          |`Collection.exists`
+|`Bucket.get_from_replica`|`Collection.get_any_replica`and_`collection_get_all_replicas`
+|`Bucket.get_and_lock`    |`Collection.get_and_lock`
+|`Bucket.get_and_touch`   |`Collection.get_and_touch`
+|`Bucket.insert`          |`Collection.insert`
+|`Bucket.upsert`          |`Collection.upsert`
+|`Bucket.replace`         |`Collection.replace`
+|`Bucket.remove`          |`Collection.remove`
+|`Bucket.unlock`          |`Collection.unlock`
+|`Bucket.touch`           |`Collection.touch`
+|`Bucket.lookup_in`       |`Collection.lookup_in`
+|`Bucket.mutate_in`       |`Collection.mutate_in`
+|`Bucket.counter`         |`BinaryCollection.increment` and `BinaryCollection.decrement`
+|`Bucket.append`          |`BinaryCollection.append`
+|`Bucket.prepend`         |`BinaryCollection.prepend`
+|====
+
+In addition, the datastructure APIs have been renamed and moved:
+
+.Datastructure API Changes
+[options="header"]
+|====
+| SDK 2                          | SDK 3
+|`Bucket.mapAdd`                 | `Collection.map`
+|`Bucket.mapGet`                 | `Collection.map`
+|`Bucket.mapRemove`              | `Collection.map`
+|`Bucket.mapSize`                | `Collection.map`
+|`Bucket.listGet`                | `Collection.list`
+|`Bucket.listAppend`             | `Collection.list`
+|`Bucket.listRemove`             | `Collection.list`
+|`Bucket.listPrepend`            | `Collection.list`
+|`Bucket.listSet`                | `Collection.list`
+|`Bucket.listSize`               | `Collection.list`
+|`Bucket.setAdd`                 | `Collection.set`
+|`Bucket.setContains`            | `Collection.set`
+|`Bucket.setRemove`              | `Collection.set`
+|`Bucket.setSize`                | `Collection.set`
+|`Bucket.queuePush`              | `Collection.queue`
+|`Bucket.queuePop`               | `Collection.queue`
+|====
+
+There are two important API changes:
+
+* On the request side, overloads have been reduced and moved under a `Options` block
+* On the response side, the return types have been unified.
+
+The signatures now look very similar.
+The concept of the `Document` as a type is gone in SDK 3 and instead you need to pass in the properties explicitly.
+This makes it very clear what is returned, especially on the response side.
+
+Thus, the `get` method does not return a `Document` but a `GetResult` instead, and the `upsert` does not return a `Document` but a `MutationResult`.
+Each of those results only contains the field that the specific method can actually return, making it impossible to accidentally try to access the `expiry` on the `Document` after a mutation, for example.
+
+Instead of having many overloads, all optional params are now part of the `Option` block.
+All required params are still part of the method signature, making it clear what is required and what is not (or has default values applied if not overridden).
+
+The timeout can be overridden on every operation and now takes a `datetime.timedelta` object from the Python standard library.
+
+[source,python]
+
+----
+include::example$migrating.py[tag=customtimeout,indent=0]
+----
+
+In SDK 2, the `get_from_replica` method had a `ReplicaMode` argument which allowed to customize its behavior on how many replicas should be reached.
+We have identified this as a potential source of confusion and as a result split it up in two methods that simplify usage significantly.
+There is now a `getAllReplicas` method and a `getAnyReplica` method.
+
+* `get_all_replicas` asks the active node and all available replicas and returns the results as a stream.
+* `get_any_replica` uses `get_all_replicas`, and returns the first result obtained.
+
+Unless you want to build some kind of consensus between the different replica responses, we recommend `get_any_replica` for a fallback to a regular `get` when the active node times out.
+
+NOTE: Operations which cannot be performed on JSON documents have been moved to the `BinaryCollection`, accessible through `Collection.binary()`.
+These operations include `append`, `prepend`, `increment`, and `decrement` (previously called `counter` in SDK 2).
+These operations should only be used against non-json data.
+Similar functionality is available through `mutateIn` on JSON documents.
+
+=== Query
+
+N1QL querying is now available at the `Cluster` level instead of the bucket level, because you can also write N1QL queries that span multiple buckets. Compare a simple N1QL query from SDK 2 with its SDK 3 equivalent:
+
+[source,python]
+
+----
+include::example$migrating.py[tag=querysimple_sdk2,indent=0]
+----
+
+[source,python]
+
+----
+include::example$migrating.py[tag=querysimple,indent=0]
+----
+
+Note that there is no `N1qlQuery.simple` any more -- parameter option have been moved to the `queryOptions()` for consistency reasons.
+The following shows how to do named and positional parameters in SDK 2, and their SDK 3 counterparts:
+
+[source,python]
+
+----
+include::example$migrating.py[tag=queryparameterized_sdk2,indent=0]
+
+----
+
+[source,python]
+
+----
+include::example$migrating.py[tag=queryparameterized,indent=0]
+----
+
+If you want to use prepared statements, the `adhoc()` method is still available on the `QueryOptions`, alongside every other option that used to be exposed on the SDK 2 Query options.
+
+Much of the non-row metadata has been moved into a specific `QueryMetaData` section:
+
+.Query Metadata Changes
+[options="header"]
+|====
+| SDK 2                             | SDK 3
+|`N1qlQueryResult.signature`        | `QueryResult.metaData.signature`
+|`N1qlQueryResult.info`             | `QueryResult.metaData.metrics`
+|`N1qlQueryResult.profileInfo`      | `QueryResult.metaData.profile`
+|`N1qlQueryResult.parseSuccess`     | removed
+|`N1qlQueryResult.finalSuccess`     | removed
+|`N1qlQueryResult.status`           | `QueryResult.metaData.status`
+|`N1qlQueryResult.errors`           | throws an Exception on `QueryResult`
+|`N1qlQueryResult.requestId`        | `QueryResult.metaData.requestId`
+|`N1qlQueryResult.clientContextId`  | `QueryResult.metaData.clientContextId`
+|====
+
+It is no longer necessary to check for a specific error in the stream: if an error happened during processing it will throw an exception at the top level of the query.
+The reactive streaming API will terminate the rows' `Flux` with an exception as well as soon as it is discovered.
+This makes error handling much easier in both the blocking and non-blocking cases.
+
+While in SDK 2 you had to manually check for errors (otherwise you'd get an empty row collection):
+
+[source,python]
+
+----
+N1qlQueryResult queryResult = bucket.query(N1qlQuery.simple("select 1="));
+if (!queryResult.errors().isEmpty()) {
+  // errors contain [{"msg":"syntax error - at end of input","code":3000}]
+}
+----
+
+In SDK 3 the top level `query` method will throw an exception:
+
+[source]
+----
+Exception in thread "main" com.couchbase.client.core.error.ParsingFailedException: Parsing of the input failed {"completed":true,"coreId":1,"errors":[{"code":3000,"message":"syntax error - at end of input"}],"idempotent":false,"lastDispatchedFrom":"127.0.0.1:51703","lastDispatchedTo":"127.0.0.1:8093","requestId":5,"requestType":"QueryRequest","retried":0,"service":{"operationId":"1c623a77-196a-4890-96cd-9d4f3f596477","statement":"select 1=","type":"query"},"timeoutMs":75000,"timings":{"dispatchMicros":13798,"totalMicros":70789}}
+	at com.couchbase.client.java.AsyncUtils.block(AsyncUtils.java:51)
+	at com.couchbase.client.java.Cluster.query(Cluster.java:225)
+----
+
+Not only does it throw a `CouchbaseException`, it also tries to map it to a specific exception type and include extensive contextual information for a better troubleshooting experience.
+
+=== Analytics
+
+Analytics querying, like N1QL, is also moved to the `Cluster` level: it is now accessible through the `Cluster.analyticsQuery` method.
+As with the Query service, parameters for the Analytics queries have moved into the `AnalyticsOptions`:
+
+[source,python]
+
+----
+include::example$migrating.py[tag=analyticssimple,indent=0]
+----
+
+[source,python]
+
+----
+include::example$migrating.py[tag=analyticsparameterized,indent=0]
+----
+
+Also, errors will now be thrown as top level exceptions and it is no longer necessary to explicitly check for errors:
+
+[source,python]
+
+----
+include::example$migrating.py[tag=errorcheck_sdk2,indent=0]
+----
+
+[source]
+----
+include::example$migrating.py[tag=errorcheck,indent=0]
+// SDK 3 top level exception
+com.couchbase.client.core.error.DatasetNotFoundException: The analytics dataset is not found {"completed":true,"coreId":1,"errors":[{"code":24045,"message":"Cannot find dataset foo in dataverse Default nor an alias with name foo! (in line 1, at column 15)"}],"idempotent":false,"lastDispatchedFrom":"127.0.0.1:51942","lastDispatchedTo":"127.0.0.1:8095","requestId":5,"requestType":"AnalyticsRequest","retried":0,"service":{"operationId":"80265061-62e0-4c35-860f-a07a97e1a5ee","priority":0,"statement":"select * from foo","type":"analytics"},"timeoutMs":75000,"timings":{"dispatchMicros":27005,"totalMicros":89888}}
+	at com.couchbase.client.java.AsyncUtils.block(AsyncUtils.java:51)
+	at com.couchbase.client.java.Cluster.analyticsQuery(Cluster.java:250)
+----
 
 === Search
 
- - especial focus, since the API has been reordered quite a bit
- - if applicable: Change in FTS Geospatial Lat/Lon ordering (i.e. node)
+The Search API has changed a bit in SDK 3 so that it aligns with the other query APIs.
+The type of queries have stayed the same, but all optional parameters moved into `SearchOptions`.
+Also, similar to the other query APIs, it is now available at the `Cluster` level.
+
+Here is a SDK 2 Search query with some options, and its SDK 3 equivalent:
+
+[source,python]
+
+----
+//  SDK 2 search query
+SearchQueryResult searchResult = bucket.query(new SearchQuery(
+  "indexname",
+  SearchQuery.queryString("airports")).limit(5).fields("a", "b", "c"),
+  2,
+  TimeUnit.SECONDS
+);
+for (SearchQueryRow row : searchResult.hits()) {
+  // ...
+}
+----
+
+[source,python]
+
+----
+include::example$migrating.py[tag=searchsimple,indent=0]
+----
+
+Error handling for streaming is handled differently.
+While fatal errors will still raise top-level exceptions, any errors that happend during streaming (for example if one node is down, and only partial results are returned) they will not terminate the result.
+The reasoning behind this is that usually with search results, having partial results is better than none.
+
+Here is a top level exception, for _the index does not exist_:
+
+[source]
+----
+com.couchbase.client.core.error.SearchIndexNotFoundException: The search index is not found on the server {"completed":true,"coreId":1,"httpStatus":400,"idempotent":true,"lastDispatchedFrom":"127.0.0.1:53280","lastDispatchedTo":"127.0.0.1:8094","requestId":5,"requestType":"SearchRequest","retried":0,"service":{"indexName":"myindex","type":"search"},"status":"INVALID_ARGS","timeoutMs":75000,"timings":{"dispatchMicros":12741,"totalMicros":66262}}
+	at com.couchbase.client.java.AsyncUtils.block(AsyncUtils.java:51)
+	at com.couchbase.client.java.Cluster.searchQuery(Cluster.java:275)
+----
+
+If you want to be absolutely sure that you didn't get only partial data, you can check the error map:
+
+[source,python]
+
+----
+include::example$migrating.py[tag=searchcheck,indent=0]
+----
 
 === Views
 
- - don't forget that the consistency bit has been renamed, biggest change there
+Views have stayed at the `Bucket` level, because it does not have the concept of collections and is scoped at the bucket level on the server as well.
+The API has stayed mostly the same, the most important change is that `staleness` is unified under the `ViewConsistency` enum.
+
+.View Staleness Mapping
+[options="header"]
+|====
+| SDK 2                             | SDK 3
+|`Stale.TRUE`                       | `ViewScanConsistency.NOT_BOUNDED`
+|`Stale.FALSE`                      | `ViewScanConsistency.REQUEST_PLUS`
+|`Stale.UPDATE_AFTER`               | `ViewScanConsistency.UPDATE_AFTER`
+|====
+
+Compare this SDK 2 view query with its SDK 3 equivalent:
+
+[source,python]
+
+----
+// SDK 2 view query
+ViewResult query = bucket.query(
+  ViewQuery.from("design", "view").limit(5).skip(2),
+  10,
+  TimeUnit.SECONDS
+);
+for (ViewRow row : query) {
+  // ...
+}
+----
+
+[source,python]
+
+----
+include::example$migrating.py[tag=viewquery,indent=0]
+----
+
+Exceptions are exclusively raised at the top level: for example, if the design document is not found:
+
+[source]
+----
+com.couchbase.client.core.error.ViewNotFoundException: The queried view is not found on the server {"completed":true,"coreId":1,"httpStatus":404,"idempotent":true,"lastDispatchedFrom":"127.0.0.1:53474","lastDispatchedTo":"127.0.0.1:8092","requestId":5,"requestType":"ViewRequest","retried":0,"service":{"bucket":"travel-sample","designDoc":"foo","development":false,"type":"views","viewName":"bar"},"status":"NOT_FOUND","timeoutMs":75000,"timings":{"dispatchMicros":77572,"totalMicros":189389},"viewError":"not_found","viewErrorReason":"Design document _design/foo not found"}
+	at com.couchbase.client.java.AsyncUtils.block(AsyncUtils.java:51)
+	at com.couchbase.client.java.Bucket.viewQuery(Bucket.java:182)
+
+----
 
 == Management APIs
 
  - discusses how to migrate from each old management api to the new one
  - where it is found, what exceptions it throws, etc.
 
+
+In SDK 2, the management APIs were centralized in the `Admin` class at the cluster level and the `BucketManager` class at the bucket level.
+Since SDK 3 provides more management APIs, they have been split up in their respective domains.
+So for example when in SDK 2 you needed to remove a bucket you would call `ClusterManager.removeBucket` you will now find it under `BucketManager.dropBucket`.
+Also, creating a N1QL index now lives in the `QueryIndexManager`, which is accessible through the `Cluster`.
+
+The following table provides a mapping from the SDK 2 management APIs to those of SDK 3:
+
+.SDK 2.x vs SDK 3.x ClusterManager
+[options="header"]
+|====
+| SDK 2                | SDK 3
+|`Admin.bucket_create` | `BucketManager.create_bucket`
+|`Admin.bucket_remove` | `BucketManager.drop_bucket`
+|`Admin.bucket_update` | `BucketManager.update_bucket`
+|`Admin.buckets_list`  | `BucketManager.get_all_buckets`
+|`Admin.bucket_info`   | `BucketManager.get_bucket`
+|`Admin.user_get`      | `UserManager.get_user`
+|`Admin.user_remove`   | `UserManager.drop_user`
+|`Admin.user_upsert`   | `UserManager.upsert_user`
+|`Admin.users_get`     | `UserManager.get_all_users`
+|====
+
+.SDK 2.x vs SDK 3.x BucketManager
+[options="header"]
+|====
+| SDK 2                                      | SDK 3
+| `BucketManager.design_create`              | `ViewIndexManager.upsert_design_document`
+| `BucketManager.design_delete`              | `ViewIndexManager.drop_design_document`
+| `BucketManager.design_get`                 | `ViewIndexManager.get_design_document`
+| `BucketManager.design_list`                | `ViewIndexManager.get_all_design_documents`
+| `BucketManager.design_publish`             | `ViewIndexManager.publish_design_document`
+| `BucketManager.n1ql_index_build_deferred`  | `QueryIndexManager.build_deferred_indexes`
+| `BucketManager.n1ql_index_create`          | `QueryIndexManager.create_index`
+| `BucketManager.n1ql_index_create_primary`  | `QueryIndexManager.create_primary_index`
+| `BucketManager.n1ql_index_drop`            | `QueryIndexManager.drop_index`
+| `BucketManager.n1ql_index_drop_primary`    | `QueryIndexManager.drop_primary_index`
+| `BucketManager.n1ql_index_list`            | `QueryIndexManager.get_all_indexes`
+| `BucketManager.n1ql_index_watch`           | `QueryIndexManager.watch_indexes`
+|====
+
+Extra Java stuff to be ported if possible
+
+
+
+== Reactive and Async APIs
+
+The move to Python 3 as a baseline has opened the door to expose `CompletableFuture` in addition to a reactive API.
+You can now find it under the `async()` namespace of each level (for example, `Cluster.async()` -> `AsyncCluster`).
+We also moved from `RxJava` to `Reactor` because it provides native Java 8 support and better performance out of the box.
+`Reactor` has a growing community, and integrates very well into the Spring ecosystem.
+The reactive API can now be found under the `reactive()` namespace (for example, `Collection.reactive()` -> `ReactiveCollection`).
+
+Like in SDK 2, the async and reactive APIs provide the same functionality as their blocking counterpart.
+There are only a couple places in the SDK where it does not make sense (such as the blocking datastructure APIs, which at the collection level implement the Java interfaces which do not have async or reactive counterparts).
+
+IMPORTANT: if you need to use non-blocking APIs, we recommend using the reactive one.
+The async API based on `CompletableFuture` should only be used as a building block for higher level abstractions, or if you absolutely need the last drop of performance.
+The `Flux` and `Mono` types of reactor are very powerful and allow you to build efficient and flexible domain logic without blocking.
+
+Since `Reactor` implements the reactive stream specification, you can still use `RxJava` through the interoperability interfaces.
+This is out of scope for the migration guide -- please consult the reactor and rxjava documentations for further information.
+
+As a starting point, the following types are comparable:
+
+.SDK Reactor vs RxJava
+[options="header"]
+|====
+| SDK 2 RxJava          | SDK 3 Reactor
+|`Observable<T>`        | `Flux<T>`
+|`Single<T>`            | `Mono<T>`
+|`Completable`          | `Mono<Void>`
+|====
+
+
+== Configuration Options Reference
+
+The following table provides commonly used configuration options in SDK 2 and where they can be now applied in SDK 3.
+Note that some options have been removed, and others have different ways to configure them.
+
+.SDK 2.x vs SDK 3.x Environment Configs
+[options="header"]
+|====
+| SDK 2                        | SDK 3
+|`sslEnabled`                  | `SecurityConfig.enableTls`
+|`sslKeystoreFile`             | on `CertificateAuthenticator`
+|`sslKeystorePassword`         | on `CertificateAuthenticator`
+|`sslKeystore`                 | on `CertificateAuthenticator`
+|`sslTruststoreFile`           | `SecurityConfig.trustCertificate`
+|`sslTruststorePassword`       | `SecurityConfig.trustCertificate`
+|`sslTruststore`               | `SecurityConfig.trustManagerFactory`
+|`bootstrapCarrierEnabled`     | removed
+|`bootstrapHttpDirectPort`     | via custom `SeedNode`
+|`bootstrapHttpSslPort`        | via custom `SeedNode`
+|`bootstrapCarrierDirectPort`  | via custom `SeedNode`
+|`bootstrapCarrierSslPort`     | via custom `SeedNode`
+|`ioPoolSize`                  | via custom `IoEnvironment` pools
+|`computationPoolSize`         | removed
+|`requestBufferSize`           | removed
+|`responseBufferSize`          | removed
+|`kvEndpoints`                 | `IoConfig.numKvConnections`
+|`viewEndpoints`               | `IoConfig.maxHttpConnections`
+|`queryEndpoints`              | `IoConfig.maxHttpConnections`
+|`searchEndpoints`             | `IoConfig.maxHttpConnections`
+|`userAgent`                   | removed
+|`packageNameAndVersion`       | removed
+|`observeIntervalDelay`        | removed
+|`reconnectDelay`              | removed
+|`retryDelay`                  | removed
+|`ioPool`                      | via custom `IoEnvironment` pools
+|`kvIoPool`                    | via custom `IoEnvironment` pools
+|`viewIoPool`                  | via custom `IoEnvironment` pools
+|`queryIoPool`                 | via custom `IoEnvironment` pools
+|`searchIoPool`                | via custom `IoEnvironment` pools
+|`analyticsIoPool`             | via custom `IoEnvironment` pools
+|`scheduler`                   | `scheduler`
+|`retryStrategy`               | `retryStrategy`
+|`maxRequestLifetime`          | removed
+|`keepAliveInterval`           | removed
+|`autoreleaseAfter`            | removed
+|`eventBus`                    | `eventBus`
+|`bufferPoolingEnabled`        | removed
+|`tcpNodelayEnabled`           | `IoConfig.enableTcpKeepAlives`
+|`mutationTokensEnabled`       | `IoConfig.enableMutationTokens`
+|`runtimeMetricsCollectorConfig`         | removed
+|`networkLatencyMetricsCollectorConfig`  | removed
+|`defaultMetricsLoggingConsumer`         | removed
+|`socketConnectTimeout`        | removed
+|`callbacksOnIoPool`           | removed
+|`requestBufferWaitStrategy`   | removed
+|`memcachedHashingStrategy`    | removed
+|`keyValueServiceConfig`       | removed
+|`viewServiceConfig`           | removed
+|`queryServiceConfig`          | removed
+|`searchServiceConfig`         | removed
+|`analyticsServiceConfig`      | removed
+|`configPollInterval`          | removed
+|`configPollFloorInterval`     | removed
+|`certAuthEnabled`             | on `CertificateAuthenticator`
+|`continuousKeepAliveEnabled`  | removed
+|`keepAliveErrorThreshold`     | removed
+|`keepAliveTimeout`            | removed
+|`couchbaseCoreSendHook`       | removed
+|`forceSaslPlain`              | on `PasswordAuthenticator.allowedSaslMechanisms`
+|`operationTracingEnabled`     | removed
+|`operationTracingServerDurationEnabled`  | removed
+|`tracer`                      | `requestTracer`
+|`compressionMinSize`          | `CompressionConfig.minSize`
+|`compressionMinRatio`         | `CompressionConfig.minRatio`
+|`compressionEnabled`          | `CompressionConfig.enable`
+|`orphanResponseReportingEnabled`         | removed
+|`orphanResponseReporter`                 | removed
+|`networkResolution`           | `IoConfig.networkResolution`
+|`managementTimeout`           | `TimeoutConfig.managementTimeout`
+|`queryTimeout`                | `TimeoutConfig.queryTimeout`
+|`kvTimeout`                   | `TimeoutConfig.kvTimeout`
+|`viewTimeout`                 | `TimeoutConfig.viewTimeout`
+|`searchTimeout`               | `TimeoutConfig.searchTimeout`
+|`analyticsTimeout`            | `TimeoutConfig.analyticsTimeout`
+|`connectTimeout`              | `TimeoutConfig.connectTimeout`
+|`disconnectTimeout`           | `TimeoutConfig.disconnectTimeout`
+|`dnsSrvEnabled`               | `IoConfig.enableDnsSrv`
+|`cryptoManager`               | removed
+|`propagateParentSpan`         | removed
+|====
 


### PR DESCRIPTION
Finished first pass of Java to Python port
Do Admin->Bucket/UserManager and BucketManager->View/QueryIndexManager translation tables.
Rename examples to example to match Java structure
Correct nav bar
Remove irrelevant material
Various tweaks