### PR TITLE
add import to python subdocument example

### DIFF
--- a/modules/howtos/examples/subdocument_ops.py
+++ b/modules/howtos/examples/subdocument_ops.py
@@ -64,11 +64,14 @@ The latter saves even more bandwidth by not retrieving the contents of the path 
 [source,csharp]
 ----
 """
-from couchbase.collection import CBCollection
+
+#tag::content_as[]
+import couchbase.collection
 import couchbase.subdocument as SD
 from couchbase.durability import Durability
-collection = CBCollection()
-#tag::content_as[]
+
+
+collection = couchbase.collection.Collection()
 
 result = collection.lookup_in("customer123", [SD.get("addresses.delivery.country")])
 country = result.content_as[str](0) # "United Kingdom"

--- a/modules/howtos/pages/subdocument-operations.adoc
+++ b/modules/howtos/pages/subdocument-operations.adoc
@@ -68,8 +68,6 @@ The latter saves even more bandwidth by not retrieving the contents of the path 
 .Retrieve sub-document value
 [source,python]
 ----
-import couchbase.subdocument as SD
-
 include::example$subdocument_ops.py[tag=content_as]
 ----
 

--- a/modules/howtos/pages/subdocument-operations.adoc
+++ b/modules/howtos/pages/subdocument-operations.adoc
@@ -68,6 +68,8 @@ The latter saves even more bandwidth by not retrieving the contents of the path 
 .Retrieve sub-document value
 [source,python]
 ----
+import couchbase.subdocument as SD
+
 include::example$subdocument_ops.py[tag=content_as]
 ----
 


### PR DESCRIPTION
Not sure if this will do what I think it'll do, but wanting to add a import to the example so the reader doesn't have to dig around.