### PR TITLE
PYCBC-1141:  Transcoder docs and examples

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -18,6 +18,7 @@
 .Advanced Data Operations
 * xref:howtos:concurrent-async-apis.adoc[Async APIs]
 * xref:howtos:concurrent-document-mutations.adoc[Concurrent Document Mutations]
+* xref:howtos:transcoders-nonjson.adoc[Transcoders & Non-JSON]
 //* xref:howtos:durability.adoc[Durability]
 * xref:howtos:working-with-collections.adoc[Working with Collections]
 

--- a/modules/howtos/examples/transcoders.py
+++ b/modules/howtos/examples/transcoders.py
@@ -1,0 +1,124 @@
+"""
+Make sure to install the following for the example to work:
+    python3 -m pip install orjson msgpack
+
+Must have Couchbase Python SDK v 3.2.2 or greater to use Transcoders
+"""
+
+import traceback
+from typing import Any, Tuple
+
+import orjson
+import msgpack
+
+from couchbase.cluster import Cluster, ClusterOptions
+from couchbase.auth import PasswordAuthenticator
+from couchbase.collection import GetOptions, UpsertOptions
+from couchbase.exceptions import CouchbaseException, ValueFormatException
+from couchbase.transcoder import RawJSONTranscoder, RawStringTranscoder, RawBinaryTranscoder, Transcoder
+
+cluster = Cluster("couchbase://localhost", ClusterOptions(
+    PasswordAuthenticator("Administrator", "password")))
+bucket = cluster.bucket("default")
+collection = bucket.default_collection()
+
+# tag::raw_json_encode[]
+transcoder = RawJSONTranscoder()
+user = {"name": "John Smith", "age": 27}
+
+data = orjson.dumps(user)
+try:
+    _ = collection.upsert(
+        "john-smith", data, UpsertOptions(transcoder=transcoder))
+except (ValueFormatException, CouchbaseException) as ex:
+    traceback.print_exc()
+# end::raw_json_encode[]
+
+# tag::raw_json_decode[]
+try:
+    get_result = collection.get("john-smith", GetOptions(transcoder=transcoder))
+except (ValueFormatException, CouchbaseException) as ex:
+    traceback.print_exc()
+
+decoded = orjson.loads(get_result.content)
+assert decoded == user
+# end::raw_json_decode[]
+
+# tag::raw_string_transcoder[]
+transcoder = RawStringTranscoder()
+input_str = "Hello, World!"
+
+try:
+    _ = collection.upsert(
+        "key", input_str, UpsertOptions(transcoder=transcoder))
+
+    get_result = collection.get("key", GetOptions(transcoder=transcoder))
+except (ValueFormatException, CouchbaseException) as ex:
+    traceback.print_exc()
+
+assert get_result.content == input_str
+# end::raw_string_transcoder[]
+
+# tag::raw_binary_transcoder[]
+transcoder = RawBinaryTranscoder()
+input_bytes = bytes("Hello, World!", "utf-8")
+
+try:
+    _ = collection.upsert(
+        "key", input_bytes, UpsertOptions(transcoder=transcoder))
+
+    get_result = collection.get("key", GetOptions(transcoder=transcoder))
+except (ValueFormatException, CouchbaseException) as ex:
+    traceback.print_exc()
+
+assert get_result.content == input_bytes
+# end::raw_binary_transcoder[]
+
+
+# tag::create_custom_transcoder[]
+class MessagePackTranscoder(Transcoder):
+    _CUSTOM_FLAGS = (1 << 24) | (ord("M") << 16) | (ord("P") << 8) | (ord("K") << 0)
+
+    def encode_value(self,  # type: "MessagePackTranscoder"
+                     value  # type: Any
+                     ) -> Tuple[bytes, int]:
+
+        try:
+            packed = msgpack.packb(value)
+            return packed, self._CUSTOM_FLAGS
+        except Exception as ex:
+            # Implement custom exception handling
+            print("Exception: {}".format(ex))
+            raise
+
+    def decode_value(self,  # type: "MessagePackTranscoder"
+                     value,  # type: bytes
+                     flags  # type: int
+                     ) -> bytes:
+
+        if flags != self._CUSTOM_FLAGS:
+            raise ValueError("Unexpected flags value.")
+
+        try:
+            return msgpack.unpackb(value)
+        except Exception as ex:
+            # Implement custom exception handling
+            print("Exception: {}".format(ex))
+            raise
+# end::create_custom_transcoder[]
+
+
+# tag::use_custom_transcoder[]
+transcoder = MessagePackTranscoder()
+user = {"name": "John Smith", "age": 27}
+
+try:
+    _ = collection.upsert(
+        "mpk_key", user, UpsertOptions(transcoder=transcoder))
+
+    get_result = collection.get("mpk_key", GetOptions(transcoder=transcoder))
+except (ValueFormatException, CouchbaseException) as ex:
+    traceback.print_exc()
+
+assert get_result.content == user
+# end::use_custom_transcoder[]

--- a/modules/howtos/pages/transcoders-nonjson.adoc
+++ b/modules/howtos/pages/transcoders-nonjson.adoc
@@ -1,5 +1,5 @@
 = Transcoders & Non-JSON Documents
-:description: The Java SDK supports common JSON document requirements out-of-the-box.
+:description: The Python SDK supports common JSON document requirements out-of-the-box.
 :nav-title: Using Transcoders
 :page-topic-type: howtos
 
@@ -7,32 +7,33 @@
 {description}
 Custom transcoders and serializers provide support for applications needing to perform advanced operations, including supporting non-JSON data.
 
-The Java SDK uses the concepts of transcoders and serializers, which are used whenever data is sent to or retrieved from Couchbase Server.
+The Python SDK uses the concepts of transcoders and serializers, which are used whenever data is sent to or retrieved from Couchbase Server.
+
+NOTE: Transcoders are only available for the Couchbase Python Client version `3.2.2` or later.  Also, transcoders are only available to key value operations. 
+Operations using search, analytics, query, or views will use the https://docs.python.org/3.8/library/json.html[Python Standard Libary json package] for serializing and deserializing data.
 
 When sending data to Couchbase, the SDK passes the Object being sent to a transcoder.
-The transcoder can either reject the Object as being unsupported, or convert it into a `byte[]` and a Common Flag.
+The transcoder can either reject the Object as being unsupported, or convert it into a `bytes` object and a Common Flag.
 The Common Flag specifies whether the data is JSON, a non-JSON string, or raw binary data.
-It may, but does not have to, use a serializer to perform the byte conversion.
 
-On retrieving data from Couchbase, the fetched `byte[]` and Common Flag are passed to a transcoder.  
-The transcoder converts the bytes into a concrete class (the application specifies the required type) if possible.  
-It may use a serializer for this.
+On retrieving data from Couchbase, the fetched `bytes` object and Common Flag are passed to a transcoder.  
+The transcoder converts the bytes into an object (the application specifies the required object) if possible.  
 
 NOTE: Many applications will not need to be aware of transcoders and serializers, as the defaults support most standard JSON use cases.
 The information in this page is only needed if the application has an advanced use-case, likely involving either non-JSON data, or a requirement for a particular JSON serialization library.
 
 == Default Behaviour
-The `ClusterEnvironment` contains a global transcoder and serializer, which by default are  `JsonTranscoder` and `DefaultJsonSerializer`.
+The `ClusterOptions` contains a global transcoder, which by default is a `JSONTranscoder`.
 
-`DefaultJsonSerializer` uses the high-performance JSON library https://github.com/FasterXML/jackson[Jackson] for serializing and deserializing byte arrays to and from concrete objects.
+`JSONTranscoder` uses the https://docs.python.org/3.8/library/json.html[Python Standard Libary json package] for serializing and deserializing data.
 
-On sending data to Couchbase, `JsonTranscoder` will send Objects to its serializer (`DefaultJsonSerializer` by default) to convert into a `byte[]`.
+On sending data to Couchbase, `JsonTranscoder` will send Objects to its serializer to convert into a `bytes` object.
 The serialized bytes are then sent to the Couchbase Server, along with a Common Flag of JSON.
 
-`JsonTranscoder` will pass any Object to its serializer, apart from a `byte[]`.  
-It will reject this with an InvalidArgumentException, as it is ambiguous how it should be handled.
+`JSONTranscoder` will pass any object to its serializer, apart from a `bytes` or `bytearray` object.  
+It will reject this with an `ValueFormatException`, as it is ambiguous how it should be handled.
 
-On retrieving data from Couchbase, `JsonTranscoder` passes the fetched `byte[]` and Common Flag to its serializer (`DefaultJsonSerializer` by default) to convert into a concrete class.
+On retrieving data from Couchbase, `JSONTranscoder` passes the fetched `bytes` object and Common Flag to its serializer to convert into a concrete object.
 
 This table summarizes that information, and this more concise form will be used to describe the other transcoders included in the SDK.
 
@@ -42,41 +43,25 @@ This table summarizes that information, and this more concise form will be used 
 |Result
 |Common Flag
 
-|String
+|str
 |Results of serializer
 |JSON
 
-|byte[]
-|InvalidArgumentException
+|bytes/bytearray
+|ValueFormatException
 |-
 
-|Other `Object`
+|other
 |Results of serializer
 |JSON
 |===
 
-
-For now, see the https://docs.couchbase.com/sdk-api/couchbase-python-client/api/transcoder.html[API documentation] for further details.
-
-
-
-
-
-////
-== Using Custom Jackson
-As described above, the default serializer (`DefaultJsonSerializer`) uses Jackson for serializing objects.
-(This Jackson dependency is shaded into a different namespace, so that it does not clash with any Jackson used by your application.)
-
-If Jackson is on the application's classpath, the SDK will instead automatically default to using this.
-It does this during `ClusterEnvironment` creation: if no serializer has been specified, and if Jackson is detected on the classpath, then a `JacksonJsonSerializer` is used as the global default serializer instead of `DefaultJsonSerializer`.  
-This will create and use a Jackson `ObjectMapper` from the standard `com.fasterxml.jackson.databind` package.
-
-== RawJsonTranscoder
-The RawJsonTranscoder provides the ability for the application to explicitly specify that the data they are storing or retrieving is JSON.
-This transcoder does not accept a serializer, and always performs straight pass through of the data to the server.
+== RawJSONTranscoder
+The `RawJSONTranscoder` provides the ability for the application to explicitly specify that the data they are storing or retrieving is JSON.
+This transcoder does not use a serializer, and always performs straight pass through of the data to the server.
 This enables the application to avoid unnecessary parsing costs when they are certain they are using JSON data.
 
-It only accepts Strings and `byte[]`.
+It only accepts `str` and `bytes` or `bytearray` objects.
 
 [cols="3", options="header"]
 |===
@@ -84,52 +69,52 @@ It only accepts Strings and `byte[]`.
 |Result
 |Common Flag
 
-|String
+|str
 |Passthrough
 |JSON
 
-|byte[]
+|bytes/bytearray
 |Passthrough
 |JSON
 
-|Other `Object`
-|InvalidArgumentException
+|Other
+|ValueFormatException
 |-
 |===
 
 This transcoder is particularly useful when working with third-party JSON libraries.
-Here we want to use https://github.com/google/gson[Google Gson] for serialization, instead of the default Jackson:
+Here we want to use https://pypi.org/project/orjson[orjson] for serialization, instead of the default json package:
 
-[source,java]
+[source,python]
 ----
-include::example$Transcoding.java[tag=gson-encode,indent=0]
+include::howtos:example$transcoders.py[tag=raw_json_encode]
 ----
 
-Since Gson has already done the serialization work, we don't want to use the default `JsonTranscoder`, as this will run the provided String needlessly through `DefaultJsonSerializer` (Jackson).
-Instead, RawJsonTranscoder is used, which just passes through the serialized bytes, and stores them in Couchbase with the JSON Common Flag set.
+Since orjson has already done the serialization work, we don't want to use the default `JSONTranscoder`, as this will run the provided string needlessly through `json.loads`.
+Instead, `RawJSONTranscoder` is used, which just passes through the serialized bytes, and stores them in Couchbase with the JSON Common Flag set.
 
-Similarly, the same transcoder is used on reading the document, so the raw bytes can be retrieved in a String without going through `DefaultJsonSerializer` (Jackson).  
-Gson can then be used for the deserialization.
+Similarly, the same transcoder is used on reading the document, so the raw bytes can be retrieved in a string without going through `json.dumps`.
+orjson can then be used for the deserialization.
 
-[source,java]
+[source,python]
 ----
-include::example$Transcoding.java[tag=gson-decode,indent=0]
+include::howtos:example$transcoders.py[tag=raw_json_decode]
 ----
 
 == Non-JSON Transcoders
 It is most common to store JSON with Couchbase.
-However, it is possible to store non-JSON documents, such as raw binary data, perhaps using an concise binary encoding like https://msgpack.org[MessagePack] or https://cbor.io/[CBOR], in the Key-Value store.
+However, it is possible to store non-JSON documents, such as raw binary data.
 
-NOTE: It's important to note that the Couchbase Data Platform includes multiple components other than the Key-Value store -- including N1QL and its indexes, FTS, analytics, and eventing -- and these are optimized for JSON and will either ignore or provide limited functionality with non-JSON documents.
+NOTE: It's important to note that the Couchbase Data Platform includes multiple components other than the Key-Value store -- including N1QL (Query) and its indexes, FTS (Search), analytics, and eventing -- and these are optimized for JSON and will either ignore or provide limited functionality with non-JSON documents.
 
 Also note that some simple data types can be stored directly as JSON, without recourse to non-JSON transcoding.
 A valid JSON document can be a simple integer (`42`), string (`"hello"`), array (`[1,2,3]`), boolean (`true`, `false`) and the JSON `null` value.
 
 === RawStringTranscoder
-The RawStringTranscoder provides the ability for the user to explicitly store and retrieve raw string data with Couchbase.
+The `RawStringTranscoder` provides the ability for the user to explicitly store and retrieve raw string data with Couchbase.
 It can be used to avoid the overhead of storing the string as JSON, which requires two bytes for double quotes, plus potentially more for escaping characters.
 
-Note that this transcoder does not accept a serializer, and always performs straight passthrough of the data to the server.  It only accepts Strings.
+Note that this transcoder does not accept a serializer, and always performs straight passthrough of the data to the server.  It only accepts str objects.
 
 [cols="3", options="header"]
 |===
@@ -137,28 +122,28 @@ Note that this transcoder does not accept a serializer, and always performs stra
 |Result
 |Common Flag
 
-|String
+|str
 |Passthrough
 |String
 
-|byte[]
-|InvalidArgumentException
+|bytes/bytearray
+|ValueFormatException
 |-
 
-|Other `Object`
-|InvalidArgumentException
+|other
+|ValueFormatException
 |-
 |===
 
 Here’s an example of using the `RawStringTranscoder`:
 
-[source,java]
+[source,python]
 ----
-include::example$Transcoding.java[tag=string,indent=0]
+include::howtos:example$transcoders.py[tag=raw_string_transcoder]
 ----
 
 === RawBinaryTranscoder
-The RawBinaryTranscoder provides the ability for the user to explicitly store and retrieve raw byte data to Couchbase.
+The `RawBinaryTranscoder` provides the ability for the user to explicitly store and retrieve raw byte data to Couchbase.
 The transcoder does not perform any form of real transcoding, and does not take a serializer, but rather passes the data through and assigns the appropriate binary Common Flag.
 
 [cols="3", options="header"]
@@ -167,105 +152,58 @@ The transcoder does not perform any form of real transcoding, and does not take 
 |Result
 |Common Flag
 
-|String
-|InvalidArgumentException
+|str
+|ValueFormatException
 |-
 
-|byte[]
+|bytes/bytearray
 |Passthrough
 |Binary
 
-|Other `Object`
-|InvalidArgumentException
+|other
+|ValueFormatException
 |-
 |===
 
 Here’s an example of using the `RawBinaryTranscoder`:
 
-[source,java]
+[source,python]
 ----
-include::example$Transcoding.java[tag=binary,indent=0]
+include::howtos:example$transcoders.py[tag=raw_binary_transcoder]
 ----
 
-== Custom Transcoders and Serializers
+== Custom Transcoders
 More advanced transcoding needs can be accomplished if the application implements their own transcoders and serializers.
-
-=== Creating a Custom Serializer
-We saw above one example of using Google Gson with the `RawJsonTranscoder`, but it requires the application to explicitly serialize and deserialize objects each time.  
-By creating a custom Gson serializer, we can avoid this.
-
-It’s easy to create a serializer.  Simply implement the `JsonSerializer` interface’s three methods:
-[source,java]
-----
-include::example$Transcoding.java[tag=gson-serializer,indent=0]
-----
-
-NOTE: The `TypeRef` overload is optional, and is only used if the application explicitly uses it with for example `result.contentAs(new TypeRef<String> {})`, which is an uncommon requirement.  
-It is fine to throw an exception from this method rather than implementing it, if it is not needed.
-
-In this case, there is no need to provide a custom transcoder.
-The <<Default Behaviour,table for `JsonTranscoder`>> shows that it already does what we need: for any Object (that’s not a `byte[]`), it sends it to its serializer, and then stores the result in Couchbase with the JSON Common Flag set.
-All we need to do is change the serializer, as so:
-
-[source,java]
-----
-include::example$Transcoding.java[tag=gson-custom-encode,indent=0]
-----
-
-And for decoding:
-
-[source,java]
-----
-include::example$Transcoding.java[tag=gson-custom-decode,indent=0]
-----
-
-If you want to use Gson for all JSON serialization, you can register it as the global JSON serializer when creating a `ClusterEnvironment`:
-
-[source,java]
-----
-include::example$Transcoding.java[tag=gson-register-1,indent=0]
-----
-
-The default global `JsonTranscoder` will be initialized with this serializer.
-Now our GsonSerializer will be automatically used by all operations, without needing to provide a transcoder each time.
 
 === Creating a Custom Transcoder
 Let’s look at a more complex example: encoding the JSON alternative, https://msgpack.org[MessagePack].
-MessagePack is a compact binary data representation, so it should be stored with the binary Common Flag.
-The Common Flag is chosen by the transcoder, and none of the existing transcoders matches our needs (`RawBinaryTranscoder` does set the binary flag, but it passes data through directly rather than using a serializer).  
+MessagePack is a compact binary data representation which is custom to our needs, so it should be stored with our with own Common Flag.
+The Common Flag is chosen by the transcoder, and none of the existing transcoders matches our needs (`RawBinaryTranscoder` does set the binary flag, but it passes data through directly rather than using a serializer, which could also cause issues if you access data through different SDKs).
 So we need to write one.
 
-Start by creating a new serializer for MessagePack.  This is similar to the GsonSerializer example above:
+We create a transcoder that uses the `msgpack.packb`/`msgpack.unpackb` methods, and sets the our own Common Flag when storing the data:
 
-[source,java]
+[source,python]
 ----
-include::example$Transcoding.java[tag=msgpack-serializer,indent=0]
-----
-
-And now create a transcoder that uses the `MsgPackSerializer`, and sets the binary Common Flag when storing the data:
-
-[source,java]
-----
-include::example$Transcoding.java[tag=msgpack-transcoder,indent=0]
+include::howtos:example$transcoders.py[tag=create_custom_transcoder]
 ----
 
-Note the use of `BINARY_COMPAT_FLAGS`.  The other Common Flags that can be used are `JSON_COMPAT_FLAGS` and `STRING_COMPAT_FLAGS`.  
-Any other flags in `CodecFlags` are for legacy purposes and internal SDK usage, and should not be used.
+Note the use of a private property `_CUSTOM_FLAGS`.
+We are setting the flags to our own value so that our data cannot be misread by any other SDK accessing the data.
+We'd have to implement our transcoder in those SDKs too.
+The `(1 << 24)` value actually corresponds to an internal SDK flag signifying that the datatype is private, we then encode our own `MPK` flag into it.
 
 Now we can use the new transcoder to seamlessly store MessagePack data in Couchbase Server:
 
-[source,java]
+[source,python]
 ----
-include::example$Transcoding.java[tag=msgpack-encode,indent=0]
+include::howtos:example$transcoders.py[tag=use_custom_transcoder]
 ----
+
+See the https://github.com/msgpack/msgpack-python[msgpack-python docs] for further details on what the package can do.
 
 == Further reading
 
-* For _Common flags_, setting the data format used, see the xref:ref:data-structures.adoc#common-flags[Data Structures reference].
-* _Format flags_ for ancient SDKs are still available for compatibility, if you are porting a long-lived legacy app. 
-See the xref:ref:data-structures.adoc#legacy-formats[Legacy formats reference].
 * If you want to work with binary documents and our Search service, you might like to take a look at https://github.com/khanium/couchbase-fts-binary
-
-////
 
 


### PR DESCRIPTION
Hi @osfameron - I added a note to mention that transcoders are available with v 3.2.2 or later.  It is mix in with a note on transcoders also only being available for KV ops.  Didn't know if I should split those up or not.  Lemme know what you think.  Thanks!