### PR TITLE
AV-35207 - Restructure Distributed ACID Transactions documentation

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -15,10 +15,18 @@
 * xref:howtos:full-text-searching-with-sdk.adoc[Full Text Search]
 * xref:howtos:view-queries-with-sdk.adoc[MapReduce Views]
 
+.Transactions
+* xref:howtos:distributed-acid-transactions-from-the-sdk.adoc[How-to Guide]
+// TODO: Add Single Query and Tracing when available in Python SDK
+//** xref:howtos:transactions-single-query.adoc[Single Query Transactions]
+//** xref:howtos:transactions-tracing.adoc[Tracing]
+* xref:concept-docs:transactions.adoc[Key Concepts]
+** xref:concept-docs:transactions-cleanup.adoc[Cleanup]
+** xref:concept-docs:transactions-error-handling.adoc[Error Handling]
+
 .Advanced Data Operations
 * xref:howtos:concurrent-async-apis.adoc[Async APIs]
 * xref:howtos:concurrent-document-mutations.adoc[Concurrent Document Mutations]
-* xref:howtos:distributed-acid-transactions-from-the-sdk.adoc[Distributed ACID Transactions]
 * xref:howtos:encrypting-using-sdk.adoc[Encrypting Your Data]
 * xref:howtos:transcoders-nonjson.adoc[Transcoders & Non-JSON]
 //* xref:howtos:durability.adoc[Durability]

--- a/modules/concept-docs/pages/transactions-cleanup.adoc
+++ b/modules/concept-docs/pages/transactions-cleanup.adoc
@@ -1,0 +1,47 @@
+= Cleanup
+:description: The SDK takes care of failed or lost transactions, using an asynchronous cleanup background task.
+:page-toclevels: 2
+:page-pagination: full
+
+[abstract]
+{description}
+
+include::project-docs:partial$attributes.adoc[]
+include::howtos:partial$acid-transactions-attributes.adoc[]
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=cleanup;!library-cleanup-buckets]
+
+[#tuning-cleanup]
+=== Configuring Cleanup
+
+The cleanup settings can be configured as so:
+
+[options="header"]
+|===
+|Setting|Default|Description
+|`cleanup_window`|60 seconds|This determines how long a cleanup 'run' is; that is, how frequently this client will check its subset of ATR documents.  It is perfectly valid for the application to change this setting, which is at a conservative default.  Decreasing this will cause expiration transactions to be found more swiftly (generally, within this cleanup window), with the tradeoff of increasing the number of reads per second used for the scanning process.
+|`cleanup_lost_attempts`|true|This is the thread that takes part in the distributed cleanup process described above, that cleans up expired transactions created by any client.  It is strongly recommended that it is left enabled.
+|`cleanup_client_attempts`|true|This thread is for cleaning up transactions created just by this client.  The client will preferentially aim to send any transactions it creates to this thread, leaving transactions for the distributed cleanup process only when it is forced to (for example, on an application crash).  It is strongly recommended that it is left enabled.
+|===
+
+=== Monitoring Cleanup
+
+To monitor cleanup, increase the verbosity on the logging.
+
+//TODO: once events are available, re-add the below with relevant examples
+//[source,java]
+//----
+//include::example$TransactionsExample.java[tag=cleanup-events,indent=0]
+//----
+//
+//`TransactionCleanupEndRunEvent` is raised whenever a current 'run' is finished, and contains statistics from the run.
+//(A run is typically around every 60 seconds, with default configuration.)
+//
+//A `TransactionCleanupAttempt` event is raised when an expired transaction was found by this process, and a cleanup attempt was made.
+//It contains whether that attempt was successful, along with any logs relevant to the attempt.
+//
+//In addition, if cleanup fails to cleanup a transaction that is more than two hours past expiry, it will raise the `TransactionCleanupAttempt` event at WARN level (rather than the default DEBUG).
+//With most default configurations of the event-bus (see <<Logging>> below), this will cause that event to be logged somewhere visible to the application.
+//If there is not a good reason for the cleanup to be failed (such as a downed node that has not yet been failed-over), then the user is encouraged to report the issue.
+
+Please see the xref:howtos:collecting-information-and-logging.adoc[Node.js SDK logging documentation] for details.

--- a/modules/concept-docs/pages/transactions-error-handling.adoc
+++ b/modules/concept-docs/pages/transactions-error-handling.adoc
@@ -1,0 +1,35 @@
+= Error Handling
+:description: Handling transaction errors with Couchbase.
+:page-toclevels: 2
+:page-pagination: prev
+
+[abstract]
+{description}
+
+include::project-docs:partial$attributes.adoc[]
+include::howtos:partial$acid-transactions-attributes.adoc[]
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=error-intro]
+
+== Transaction Errors
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=error]
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=txnfailed]
+
+// TODO: Need an equivalent python snippet for the below
+//[source,java]
+//----
+//include::example$TransactionsExample.java[tag=config-expiration,indent=0]
+//----
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=txnfailed1]
+
+=== Full Error Handling Example
+
+Pulling all of the above together, this is the suggested best practice for error handling:
+
+[source,python]
+----
+include::howtos:example$transactions_example.py[tag=complete_error_handling,indent=0]
+----

--- a/modules/concept-docs/pages/transactions.adoc
+++ b/modules/concept-docs/pages/transactions.adoc
@@ -1,0 +1,68 @@
+= Distributed ACID Transactions
+:description:  A high-level overview of Distributed ACID Transactions with Couchbase.
+:page-toclevels: 2
+:page-pagination: next
+
+include::project-docs:partial$attributes.adoc[]
+include::howtos:partial$acid-transactions-attributes.adoc[]
+
+[abstract]
+{description}
+
+For a practical guide, see xref:howtos:distributed-acid-transactions-from-the-sdk.adoc[Distributed ACID Transactions from the Python SDK].
+
+== Overview
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=intro]
+
+== Transaction Mechanics
+
+[source,python]
+----
+include::howtos:example$transactions_example.py[tag=create-simple,indent=0]
+----
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=mechanics;!library-cleanup-process]
+
+== Rollback
+
+If an exception is thrown, either by the application from the lambda, or by the transaction internally, then that attempt is rolled back.
+The transaction logic may or may not be retried, depending on the exception.
+
+If the transaction is not retried then it will throw an exception, and its `message` property can be used to inspect the details of the failure.
+
+The application can use this to signal why it triggered a rollback, as so:
+
+[source,python]
+----
+include::howtos:example$transactions_example.py[tag=rollback_cause,indent=0]
+----
+
+After a transaction is rolled back, it cannot be committed, no further operations are allowed on it, and the system will not try to automatically commit it at the end of the code block.
+
+== Transaction Operations
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=query;!library-begin-transaction]
+
+== Concurrency with Non-Transactional Writes
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=concurrency]
+
+// TODO: uncomment once custom metadata collections are supported
+//== Custom Metadata Collections
+//
+//include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=custom-metadata-1]
+//
+//[source,python]
+//----
+//include::howtos:example$transactions_example.py[tag=custom_metadata,indent=0]
+//----
+//
+//or at an individual transaction level with:
+//
+//[source,java]
+//----
+//include::howtos:example$transactions_example.py[tag=custom_metadata_per,indent=0]
+//----
+//
+//include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=integrated-sdk-custom-metadata-2]

--- a/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
+++ b/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
@@ -3,6 +3,7 @@
 :navtitle: ACID Transactions
 :page-topic-type: howto
 :page-toclevels: 2
+:page-pagination: next
 
 include::project-docs:partial$attributes.adoc[]
 include::partial$acid-transactions-attributes.adoc[]
@@ -10,67 +11,134 @@ include::partial$acid-transactions-attributes.adoc[]
 [abstract]
 {description}
 
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=intro]
+This guide will show you examples of how to perform multi-document ACID (atomic, consistent, isolated, and durable) database transactions within your application, using the Couchbase Node.js SDK.
 
-== Requirements
+Refer to the xref:concept-docs:transactions.adoc[Distributed ACID Transactions] concept material for a high-level overview.
 
-* Couchbase Server 6.6.1 or above.
-* Couchbase Python SDK 4.0.0 or above.
+== Prerequisites
+
+[{tabs}]
+====
+Couchbase Capella::
++
+--
+* Couchbase Capella account.
+* You should know how to perform xref:howtos:kv-operations.adoc[key-value] or xref:howtos:n1ql-queries-with-sdk.adoc[query] operations with the SDK.
+* Your application should have the relevant roles and permissions on the required buckets, scopes, and collections, to perform transactional operations.
+Refer to the xref:cloud:organizations:organization-projects-overview.adoc[Organizations & Access] page for more details.
+* If your application is using xref:concept-docs:xattr.adoc[extended attributes (XATTRs)], you should avoid using the XATTR field `txn` -- this is reserved for Couchbase use.
+--
+
+Couchbase Server::
++
+--
+* Couchbase Server (6.6.1 or above).
+* You should know how to perform xref:howtos:kv-operations.adoc[key-value] or xref:howtos:n1ql-queries-with-sdk.adoc[query] operations with the SDK.
+* Your application should have the relevant roles and permissions on the required buckets, scopes, and collections, to perform transactional operations.
+Refer to the xref:{version-server}@server:learn:security/roles.adoc[Roles] page for more details.
+* If your application is using xref:concept-docs:xattr.adoc[extended attributes (XATTRs)], you should avoid using the XATTR field `txn` -- this is reserved for Couchbase use.
+* NTP should be configured so nodes of the Couchbase cluster are in sync with time.
+--
+====
+
 include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=requirements]
 
-== Getting Started
-
-Couchbase transactions require no additional components or services to be configured. 
 Simply `pip install` the most recent version of the SDK.
 You may, on occasion, need to import some enumerations for particular settings, but in basic cases nothing is needed.
 
-== Configuration
-
-Transactions can optionally be globally configured when configuring the `Cluster`.
-For example, if you want to change the level of durability which must be attained, this can be configured as part of the connect options:
-
-[source,python]
-----
-include::example$transactions_example.py[tag=config,indent=0]
-----
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=config]
+== Creating a Transaction
 
 include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=creating]
-
-[source,python]
-----
-include::example$transactions_example.py[tag=create,indent=0]
-----
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=lambda-ctx]
-
-// Examples
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=examples-intro]
 
 [source,python]
 ----
 include::example$transactions_example.py[tags=examples;!scope-example,indent=0]
 ----
 
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=mechanics;!library-cleanup-process]
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=lambda-ctx]
 
-== Key-Value Mutations
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=creating-error]
 
-=== Replacing
+=== Logging
+
+To aid troubleshooting, raise the log level on the SDK.
+// TODO: need to add logging details
+//To aid troubleshooting, each transaction maintains a list of log entries, which can be logged on failure like this:
+
+//[source,java]
+//----
+//include::example$TransactionsExample.java[tag=logging,indent=0]
+//----
+//
+//A failed transaction can involve dozens, even hundreds, of lines of logging, so the application may prefer to write failed transactions into a separate file.
+//
+//For convenience there is also a config option that will automatically write this programmatic log to the standard Couchbase Java logging configuration inherited from the SDK if a transaction fails.
+//This will log all lines of any failed transactions, to `WARN` level:
+//[source,java]
+//----
+//include::example$TransactionsExample.java[tag=config_warn,indent=0]
+//----
+//
+
+Please see the xref:howtos:collecting-information-and-logging.adoc[Python SDK logging documentation] for details.
+
+== Key-Value Operations
+
+You can perform transactional database operations using familiar key-value CRUD methods:
+
+* **C**reate - `insert()`
+
+* **R**ead - `get()`
+
+* **U**pdate - `replace()`
+
+* **D**elete - `remove()`
+
+[IMPORTANT]
+====
+As mentioned <<lambda-ops,previously>>, make sure your application uses the transactional key-value operations inside the {lambda} -- such as `ctx.insert()`, rather than `collection.insert()`.
+====
+
+=== Insert
+
+To insert a document within a transaction {lambda}, simply call `ctx.insert()`.
+
+[source,python]
+----
+include::example$transactions_example.py[tag=insert,indent=0]
+----
+
+=== Get
+
+To retrieve a document from the database you can call `ctx.get()`.
+
+[source,python]
+----
+include::example$transactions_example.py[tag=get,indent=0]
+----
+
+`ctx.get()` will return a `TransactionGetResult` object, which is very similar to the `GetResult` you are used to.
+
+Gets will "Read Your Own Writes", e.g. this will succeed:
+
+[source,python]
+----
+include::example$transactions_example.py[tag=get_read_own_writes,indent=0]
+----
+
+Of course, no other transaction will be able to read that inserted document, until this transaction reaches the commit point.
+
+=== Replace
 
 Replacing a document requires a `ctx.get()` call first.
-This is necessary so the transaction can check that the document is not involved in another transaction.
-If it is, then the transaction will handle this at the `ctx.replace()` point.
-Generally, this involves rolling back what has been done so far, and retrying the lambda.
-Handling errors should be done through try/except as in the example above.
+This is necessary so the SDK can check that the document is not involved in another transaction, and take appropriate action if so.
 
 [source,python]
 ----
 include::example$transactions_example.py[tag=replace,indent=0]
 ----
 
-=== Removing
+=== Remove
 
 As with replaces, removing a document requires a `ctx.get()` call first.
 
@@ -79,42 +147,17 @@ As with replaces, removing a document requires a `ctx.get()` call first.
 include::example$transactions_example.py[tag=remove,indent=0]
 ----
 
-=== Inserting
+== {sqlpp} Queries
 
-[source,python]
-----
-include::example$transactions_example.py[tag=insert,indent=0]
-----
+If you already use https://www.couchbase.com/products/n1ql[{sqlpp} (formerly N1QL)], then its use in transactions is very similar.
+A query returns a `TransactionQueryResult` that is very similar to the `QueryResult` you are used to, and takes most of the same options.
 
-== Key-Value Reads
+[IMPORTANT]
+====
+As mentioned <<lambda-ops,previously>>, make sure your application uses the transactional query operations inside the {lambda} -- such as `ctx.query()`, rather than `cluster.query()` or `scope.query()`.
+====
 
-From a transaction context you may get a document:
-
-[source,python]
-----
-include::example$transactions_example.py[tag=get,indent=0]
-----
-
-`get` may cause the transaction to fail with `TransactionFailed` (after rolling back any changes, of course).
-It is provided as a convenience method so the developer does not have to check the `Optional` if the document must exist for the transaction to succeed.
-
-Gets will 'read your own writes', e.g. this will succeed:
-
-[source,python]
-----
-include::example$transactions_example.py[tag=get_read_own_writes,indent=0]
-----
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=query-intro;!library-begin-transaction]
-
-=== Using N1QL
-
-If you already use N1QL from the Python SDK, then its use in transactions is very similar.
-It returns the same `QueryResult` you are used to, and takes most of the same options.
-
-You must take care to write `ctx.query()` inside the lambda however, rather than `cluster.query()` or `scope.query()`.
-
-An example of selecting some rows from the `travel-sample` bucket:
+Here is an example of selecting some rows from the `travel-sample` bucket:
 
 [source,python]
 ----
@@ -138,43 +181,27 @@ include::example$transactions_example.py[tag=query_examples_select,indent=0]
 // include::example$transactions_example.py[tag=query_examples_update,indent=0]
 // ----
 
-And an example combining SELECTs and UPDATEs.
-It's possible to call regular Python functions from the lambda, as shown here, permitting complex logic to be performed.
-Just remember that since the lambda may be called multiple times, so may the method.
+And an example combining `SELECT` and an `UPDATE`.
 
 [source,python]
 ----
 include::example$transactions_example.py[tag=query_examples_complex,indent=0]
 ----
 
-=== Read Your Own Writes
+As you can see from the snippet above, it is possible to call regular Python methods from the {lambda}, permitting complex logic to be performed.
+Just remember that since the {lambda} may be called multiple times, so may the method.
 
-As with Key-Value operations, N1QL queries support Read Your Own Writes.
-
-This example shows inserting a document and then selecting it again.
+Like key-value operations, queries support "Read Your Own Writes".
+This example shows inserting a document and then selecting it again:
 
 [source,python]
 ----
 include::example$transactions_example.py[tag=query_insert,indent=0]
 ----
 
-<1> The inserted document is only staged at this point, as the transaction has not yet committed.
+<1> The inserted document is only staged at this point, as the transaction has not yet committed. +
 Other transactions, and other non-transactional actors, will not be able to see this staged insert yet.
-<2> But the SELECT can, as we are reading a mutation staged inside the same transaction.
-
-=== Mixing Key-Value and N1QL
-
-Key-Value operations and queries can be freely intermixed, and will interact with each other as you would expect.
-
-In this example we insert a document with Key-Value, and read it with a SELECT.
-
-[source,python]
-----
-include::example$transactions_example.py[tag=query_ryow,indent=0]
-----
-
-<1> As with the 'Read Your Own Writes' example, here the insert is only staged, and so it is not visible to other transactions or non-transactional actors.
-<2> But the SELECT can view it, as the insert was in the same transaction.
+<2> But the `SELECT` can, as we are reading a mutation staged inside the same transaction.
 
 === Query Options
 
@@ -185,208 +212,38 @@ Query options can be provided via `TransactionQueryOptions`, which provides a su
 include::example$transactions_example.py[tag=query_options,indent=0]
 ----
 
-Some of the supported options are:
-
-* scan_consistency 
-* client_context_id
-* scan_wait
-* scan_cap
-* pipeline_batch
-* pipeline_cap
-* profile
-* read_only
-* adhoc
-* raw
-
-See the xref:howtos:n1ql-queries-with-sdk.adoc#query-options[QueryOptions documentation] for details on these.
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=query-perf]
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=query-single]
-
-[source,python]
-----
-include::example$transactions_example.py[tag=query_single,indent=0]
-----
-
-// TODO: Unclear whether it is possible to use the `Scope` option from TransactionQueryOptions, which doesn't seem to work at this point in time.
-// Commenting out this section until we have clarification.
-//
-// You can also run a single query transaction against a particular `Scope` (these examples will exclude the full error handling for brevity):
-//
-// [source,python]
-// ----
-// include::example$transactions_example.py[tag=query_single_scoped,indent=0]
-// ----
-//
-// and configure it:
-//
-// [source,python]
-// ----
-// include::example$transactions_example.py[tag=query_single_configured,indent=0]
-// ----
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=n1ql-rbac]
-
-== Committing
-
-// TODO: Can't find ctx.commit() for Python SDK, is this relevant?
-// Committing is automatic: if there is no explicit call to `ctx.commit()` at the end of the transaction logic callback, and no exception is thrown, it will be committed.
-Committing is automatic at the end of the code block with the transaction context.
-If no exception is thrown, it will be committed.
-If you want to rollback the transaction, simply throw an exception.
-Transactions may rollback from the transaction logic itself, various failure conditions, or from your application logic by throwing an exception.
-
-As soon as the transaction is committed, all its changes will be atomically visible to reads from other transactions.
-The changes will also be committed (or "unstaged") so they are visible to non-transactional actors, in an eventually consistent fashion.
-
-Commit is final: after the transaction is committed, it cannot be rolled back, and no further operations are allowed on it.
-
-An asynchronous cleanup process ensures that once the transaction reaches the commit point, it will be fully committed - even if the application crashes.
-
-
-// == A Full Transaction Example
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=example]
-
-[source,python]
-----
-include::example$transactions_example.py[tag=full,indent=0]
-----
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=concurrency]
-
-// TODO: This is to identify violations of cooperative (copied over from Java), not known if this is available in python/cb++
-// [source,python]
-// ----
-// include::example$transactions_example.py[tag=concurrency,indent=0]
-// ----
-//
-// These events will be raised in the event of a non-transactional write being detected and overridden.
-// The event contains the key of the document involved, to aid the application with debugging.
-
-== Rollback
-
-If an exception is thrown, either by the application from the lambda, or by the transaction internally, then that attempt is rolled back.
-The transaction logic may or may not be retried, depending on the exception.
-
-If the transaction is not retried then it will throw an exception, and its `message` property can be used to inspect the details of the failure.
-
-The application can use this to signal why it triggered a rollback, as so:
-
-[source,python]
-----
-include::example$transactions_example.py[tag=rollback_cause,indent=0]
-----
-
-After a transaction is rolled back, it cannot be committed, no further operations are allowed on it, and the system will not try to automatically commit it at the end of the code block.
-
-//  Error Handling
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=error]
-
-These are some of the exceptions that Couchbase transactions can raise to the application: `TransactionFailed`, `TransactionExpired` and `TransactionCommitAmbiguous`.
-
-// txnfailed
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=txnfailed]
-
-// TODO: Need an equivalent python snippet for the below
-//[source,java]
-//----
-//include::example$TransactionsExample.java[tag=config-expiration,indent=0]
-//----
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=txnfailed1]
-
-// TODO: Double check if this will be added in future.
-// Doesn't seem to be available for the Python SDK.
-//Similar to `TransactionResult`, `SingleQueryTransactionResult` also has an `unstagingComplete()` method.
-
-=== Full Error Handling Example
-
-Pulling all of the above together, this is the suggested best practice for error handling:
-
-[source,python]
-----
-include::example$transactions_example.py[tag=complete_error_handling,indent=0]
-----
-
-// Asynchronous Cleanup
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=cleanup;!library-cleanup-buckets]
-
-[#tuning-cleanup]
-=== Configuring Cleanup
-
-The cleanup settings can be configured as so:
-
-[options="header"]
+.Supported Transaction Query Options
 |===
-|Setting|Default|Description
-|`cleanup_window`|60 seconds|This determines how long a cleanup 'run' is; that is, how frequently this client will check its subset of ATR documents.  It is perfectly valid for the application to change this setting, which is at a conservative default.  Decreasing this will cause expiration transactions to be found more swiftly (generally, within this cleanup window), with the tradeoff of increasing the number of reads per second used for the scanning process.
-|`cleanup_lost_attempts`|true|This is the thread that takes part in the distributed cleanup process described above, that cleans up expired transactions created by any client.  It is strongly recommended that it is left enabled.
-|`cleanup_client_attempts`|true|This thread is for cleaning up transactions created just by this client.  The client will preferentially aim to send any transactions it creates to this thread, leaving transactions for the distributed cleanup process only when it is forced to (for example, on an application crash).  It is strongly recommended that it is left enabled.
+| Name | Description
+
+| `positional_parameters(Iterable[JSONType])` | Allows to set positional arguments for a parameterized query.
+| `named_parameters(Dict[str, JSONType])` | Allows you to set named arguments for a parameterized query.
+| `scan_consistency(QueryScanConsistency)` | Sets a different scan consistency for this query.
+| `client_context_id(str)` | Sets a context ID returned by the service for debugging purposes.
+| `scan_wait(timedelta)` | Allows to specify a maximum scan wait time.
+| `scan_cap(int)` | Specifies a maximum cap on the query scan size.
+| `pipeline_batch(int)` | Sets the batch size for the query pipeline.
+| `pipeline_cap(int)` | Sets the cap for the query pipeline.
+| `profile(Any)` | Allows you to enable additional query profiling as part of the response.
+| `read_only(bool)` | Tells the client and server that this query is readonly.
+| `adhoc(bool)` | If set to false will prepare the query and later execute the prepared statement.
+| `raw(Dict[str, JSONType])` | Escape hatch to add arguments that are not covered by these options.
 |===
 
-=== Monitoring Cleanup
+== Mixing Key-Value and {sqlpp}
 
-To monitor cleanup, increase the verbosity on the logging.
+Key-Value operations and queries can be freely intermixed, and will interact with each other as you would expect.
+In this example we insert a document with a key-value operation, and read it with a `SELECT` query.
 
-//TODO: once events are available, re-add the below with relevant examples
-//[source,java]
-//----
-//include::example$TransactionsExample.java[tag=cleanup-events,indent=0]
-//----
-//
-//`TransactionCleanupEndRunEvent` is raised whenever a current 'run' is finished, and contains statistics from the run.
-//(A run is typically around every 60 seconds, with default configuration.)
-//
-//A `TransactionCleanupAttempt` event is raised when an expired transaction was found by this process, and a cleanup attempt was made.
-//It contains whether that attempt was successful, along with any logs relevant to the attempt.
-//
-//In addition, if cleanup fails to cleanup a transaction that is more than two hours past expiry, it will raise the `TransactionCleanupAttempt` event at WARN level (rather than the default DEBUG).
-//With most default configurations of the event-bus (see <<Logging>> below), this will cause that event to be logged somewhere visible to the application.
-//If there is not a good reason for the cleanup to be failed (such as a downed node that has not yet been failed-over), then the user is encouraged to report the issue.
+[source,python]
+----
+include::example$transactions_example.py[tag=query_ryow,indent=0]
+----
 
-== Logging
+<1> The key-value insert operation is only staged, and so it is not visible to other transactions or non-transactional actors.
+<2> But the `SELECT` can view it, as the insert was in the same transaction.
 
-To aid troubleshooting, raise the log level on the SDK.
-// TODO: need to add logging details to the error objects
-//To aid troubleshooting, each transaction maintains a list of log entries, which can be logged on failure like this:
-
-//[source,java]
-//----
-//include::example$TransactionsExample.java[tag=logging,indent=0]
-//----
-//
-//A failed transaction can involve dozens, even hundreds, of lines of logging, so the application may prefer to write failed transactions into a separate file.
-//
-//For convenience there is also a config option that will automatically write this programmatic log to the standard Couchbase Java logging configuration inherited from the SDK if a transaction fails.
-//This will log all lines of any failed transactions, to `WARN` level:
-//[source,java]
-//----
-//include::example$TransactionsExample.java[tag=config_warn,indent=0]
-//----
-//
-
-Please see the xref:howtos:collecting-information-and-logging.adoc[Python SDK logging documentation] for details.
-
-// TODO: re-add this once tracing becomes available
-//== Tracing
-//
-//This telemetry is particularly useful for monitoring performance.
-//
-//If the underlying Couchbase Java SDK is configured for tracing, then no further work is required: transaction spans will be output automatically.
-//See the xref:howtos:observability-tracing.adoc[Couchbase Java SDK Request Tracing documentation] for how to configure this.
-//
-//=== Parent Spans
-//
-//While the above is sufficient to use and output transaction spans, the application may wish to indicate that the transaction is part of a larger span -- for instance, a user request.
-//It can do this by passing that as a parent span.
-//
-//If you have an existing OpenTelemetry span you can easily convert it to a Couchbase `RequestSpan` and pass it to the transactions library:
-//
-//[source,java]
-//----
-//include::example$TransactionsExample.java[tag=tracing-wrapped,indent=0]
-//----
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=rbac]
 
 == Concurrent Operations
 
@@ -398,58 +255,38 @@ This is because the first mutation also triggers the creation of metadata for th
 * All concurrent operations must be allowed to complete fully, so the transaction can track which operations need to be rolled back in the event of failure.
 This means the application must 'swallow' the error, but record that an error occurred, and then at the end of the concurrent operations, if an error occurred, throw an error to cause the transaction to retry.
 
-// TODO: update this for node
-//These rules are demonstrated here:
+=== Non-Transactional Writes
+
+To ensure key-value performance is not compromised, and to avoid conflicting writes, applications should *never* perform non-transactional _writes_ concurrently with transactional ones, on the same document.
+
+// TODO: update this for Node.js when available
+//You can verify this when debugging your application by subscribing to the client's event logger and checking for any `IllegalDocumentStateEvent` events.
+//These events are raised when a non-transactional write has been detected and overridden.
 
 //[source,java]
 //----
-//include::example$TransactionsExample.java[tag=concurrentOps,indent=0]
+//include::howtos:example$TransactionsExample.java[tag=concurrency,indent=0]
 //----
 
+//The event contains the key of the document involved, to aid the application with debugging.
 
-// TODO: re-enable once custom metadata collections are supported
-// include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=custom-metadata-1]
+See xref:concept-docs:transactions.adoc#concurrency-with-non-transactional-writes[Concurrency with Non-Transactional Writes] to learn more.
 
-//[source,java]
-//----
-//include::example$TransactionsExample.java[tag=custom-metadata,indent=0]
-//----
+== Configuration
 
-//include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=custom-metadata-2]
+The default configuration should be appropriate for most use-cases.
+Transactions can optionally be globally configured when configuring the `Cluster`.
+For example, if you want to change the level of durability which must be attained, this can be configured as part of the connect options:
 
-// TODO: re-enable when deferred commits are supported
-//== Deferred Commits
-//
-//NOTE: The deferred commit feature is currently in alpha, and the API may change.
-//
-//Deferred commits allow a transaction to be paused just before the commit point.
-//Optionally, everything required to finish the transaction can then be bundled up into a context that may be serialized into a String or byte array, and deserialized elsewhere (for example, in another process).
-//The transaction can then be committed, or rolled back.
-//
-//The intention behind this feature is to allow multiple transactions, potentially spanning multiple databases, to be brought to just before the commit point, and then all committed together.
-//
-//Here's an example of deferring the initial commit and serializing the transaction:
-//
-//[source,java]
-//----
-//include::example$TransactionsExample.java[tag=defer1,indent=0]
-//----
-//
-//And then committing the transaction later:
-//
-//[source,java]
-//----
-//include::example$TransactionsExample.java[tag=defer2,indent=0]
-//----
-//
-//Alternatively the transaction can be rolled back:
-//
-//[source,java]
-//----
-//include::example$TransactionsExample.java[tag=defer3,indent=0]
-//----
-//
-//The transaction expiry timer (which is configurable) will begin ticking once the transaction starts, and is not paused while the transaction is in a deferred state.
+[source,python]
+----
+include::example$transactions_example.py[tag=config,indent=0]
+----
 
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=config]
 
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=further]
+== Additional Resources
+
+* Learn more about xref:concept-docs:transactions.adoc[Distributed ACID Transactions].
+
+* Check out the SDK https://docs.couchbase.com/sdk-api/couchbase-python-client/[API Reference].

--- a/modules/howtos/pages/transactions-single-query.adoc
+++ b/modules/howtos/pages/transactions-single-query.adoc
@@ -1,0 +1,35 @@
+// TODO: Add when available for Python SDK
+//= Single Query Transactions
+//:description: Learn how to perform bulk-loading transactions with the Python SDKd.
+//:page-partial:
+//:page-topic-type: howto
+//:page-pagination: full
+//
+//include::project-docs:partial$attributes.adoc[]
+//
+//[abstract]
+//{description}
+//
+//include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=single-query-transactions-intro]
+//
+//[source,python]
+//----
+//include::example$transactions_example.py[tag=query_single,indent=0]
+//----
+//
+// TODO: Unclear whether it is possible to use the `Scope` option from TransactionQueryOptions, which doesn't seem to work at this point in time.
+// Commenting out this section until we have clarification.
+//
+// You can also run a single query transaction against a particular `Scope` (these examples will exclude the full error handling for brevity):
+//
+// [source,python]
+// ----
+// include::example$transactions_example.py[tag=query_single_scoped,indent=0]
+// ----
+//
+// and configure it:
+//
+// [source,python]
+// ----
+// include::example$transactions_example.py[tag=query_single_configured,indent=0]
+// ----

--- a/modules/howtos/pages/transactions-tracing.adoc
+++ b/modules/howtos/pages/transactions-tracing.adoc
@@ -1,0 +1,35 @@
+// TODO: Add when available for Python SDK
+//= Tracing
+//:description: Tracing Couchbase Distributed ACID transactions.
+//:page-partial:
+//:page-topic-type: howto
+//:page-pagination: full
+//
+//[abstract]
+//{description}
+//
+//If configured, detailed telemetry on each transaction can be output that is compatible with various external systems including OpenTelemetry and its predecessor OpenTracing.
+//This telemetry is particularly useful for monitoring performance.
+//
+//See the xref:howtos:observability-tracing.adoc[SDK Request Tracing documentation] for how to configure this.
+//
+//// TODO: Check if this is still the case?
+//Tracing should currently be regarded as 'developer preview' functionality, as the spans and attributes output may change over time.
+//
+//== Parent Spans
+//
+//The application may wish to indicate that the transaction is part of a larger span -- for instance, a user request.
+//It can do this by passing that as a parent span.
+//
+//This can be done using the SDK's `RequestTracer` abstraction as so:
+//[source,java]
+//----
+//include::example$TransactionsExample.java[tag=tracing,indent=0]
+//----
+//
+//Or if you have an existing OpenTelemetry span you can easily convert it to a Couchbase `RequestSpan` and pass it to the SDK:
+//
+//[source,java]
+//----
+//include::example$TransactionsExample.java[tag=tracing-wrapped,indent=0]
+//----

--- a/modules/howtos/partials/acid-transactions-attributes.adoc
+++ b/modules/howtos/partials/acid-transactions-attributes.adoc
@@ -21,3 +21,7 @@
 :transaction-config: TransactionsConfig
 :transaction-commit-ambiguous: TransactionCommitAmbiguous
 :txnfailed-unstaging-complete: TransactionResult.unstaging_complete
+
+// lambda
+:lambda: lambda
+:intro-lambda: pass:q[a `lambda`]


### PR DESCRIPTION
Page previews (including sdk-common changes, so it's easier to see it all together):

[Transactions howto guide](https://maria-robobug.github.io/transactions-reorg/python-sdk/4.0/howtos/distributed-acid-transactions-from-the-sdk.html)

[Transactions concept guide](https://maria-robobug.github.io/transactions-reorg/python-sdk/4.0/concept-docs/transactions.html)

NUX improvements:

* Splits howto and concept content as well as removing repetitive sections.

* Adds Capella in Prerequisites.

* Removes repetitive examples from asciidoc where possible.

* Moves Transactions to top level nav, include concept and howto in same section.