### PR TITLE
PYCBC-1482: Improve C++ Wrapper SDKs TLS Documentation

### DIFF
--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -218,7 +218,7 @@ For TLS certificate verification the SDK uses the following CA certificates:
 * The certificates in OpenSSL's default CA certificate store (as of SDK 4.1.0)
 * The self-signed root certificate that is used to sign the Couchbase Capella certificates (bundled with the SDK as of 4.0.0)
 
-The OpenSSL defaults can be overridden using the `SSL_CERT_DIR` and `SSL_CERT_FILE` environment variables. The `SSL_CERT_DIR` variable is used to set a specific directory in which the client should look for individual certificate files, whereas the `SSL_CERT_FILE` environment variable is used to point to a single file containing one or more certificates.
+The OpenSSL defaults can be overridden using the `SSL_CERT_DIR` and `SSL_CERT_FILE` environment variables. The `SSL_CERT_DIR` variable is used to set a specific directory in which the client should look for individual certificate files, whereas the `SSL_CERT_FILE` environment variable is used to point to a single file containing one or more certificates. More information can be found in the relevant https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_load_verify_locations.html[OpenSSL documentation].
 
 Loading the Mozilla certificates can be disabled by setting the `disable_mozilla_ca_certificates` property of `ClusterOptions`.
 

--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -218,11 +218,11 @@ For TLS certificate verification the SDK uses the following CA certificates:
 * The certificates in OpenSSL's default CA certificate store (as of SDK 4.1.0)
 * The self-signed root certificate that is used to sign the Couchbase Capella certificates (bundled with the SDK as of 4.0.0)
 
-The OpenSSL defaults can be overriden using the `SSL_CERT_DIR` and `SSL_CERT_FILE` environment variables. The `SSL_CERT_DIR` variable is used to set a specific directory in which the client should look for individual certificate files, whereas the `SSL_CERT_FILE` environment variable is used to point to a single file containing one or more certificates.
+The OpenSSL defaults can be overridden using the `SSL_CERT_DIR` and `SSL_CERT_FILE` environment variables. The `SSL_CERT_DIR` variable is used to set a specific directory in which the client should look for individual certificate files, whereas the `SSL_CERT_FILE` environment variable is used to point to a single file containing one or more certificates.
 
 Loading the Mozilla certificates can be disabled by setting the `disable_mozilla_ca_certificates` property of `ClusterOptions`.
 
-The {cbpp} core's metadata provide information on where OpenSSL's default certificate store is located,  which version of the Mozilla CA certificate store was bundled, and other useful details. You can get the metadata using the following command:
+The {cbpp} core's metadata provide information about where OpenSSL's default certificate store is located,  which version of the Mozilla CA certificate store was bundled, and other useful details. You can get the metadata using the following command:
 
 ====
 [source,console]
@@ -247,7 +247,7 @@ $ python -c "from couchbase import get_metadata; print(get_metadata(detailed=Tru
 ----
 ====
 
-With debug-level logging enabled, if the Mozilla certificates have been loaded, a message with the information on the version of the Mozilla CA certificate store will be output. For example:
+With debug-level logging enabled, if the Mozilla certificates have been loaded, a message with the information about the version of the Mozilla CA certificate store will be outputted. For example:
 
 [source]
 ----
@@ -269,7 +269,7 @@ However, as the certificate is bundled with the SDK, it is trusted by default.
 Couchbase Server::
 +
 --
-Because certificates from the Mozilla Root CA store are bundled with the SDK, if the server’s certificate is signed by a well-known CA (e.g., GoDaddy, Verisign, etc.), you no longer need to configure the `cert_path` property in the `PasswordAuthenticator` -- simply use `couchbases://` in your connection string.
+Certificates from the Mozilla Root CA store are now bundled with the SDK (as of version 4.1.5). If the server's certificate is signed by a well-known CA (e.g., GoDaddy, Verisign, etc.), you don't need to configure the `cert_path` property in the `PasswordAuthenticator` -- simply use `couchbases://` in your connection string.
 
 You can still provide a certificate explicitly if necessary:
 

--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -206,11 +206,53 @@ NOTE: Any TLS certificates must be set up at the point where the connections are
 [#ssl]
 == Secure Connections
 
-WARNING: If the client cannot load or was not built with OpenSSL, attempting an SSL connection will result in a 'FEATURE_UNAVAILABLE'.
+WARNING: If the client cannot load or was not built with OpenSSL, attempting a TLS connection will result in a 'FEATURE_UNAVAILABLE'.
 
 Couchbase Server Enterprise Edition and Couchbase Capella support full encryption of client-side traffic using Transport Layer Security (TLS).
 This includes key-value type operations, queries, and configuration communication.
 Make sure you have the Enterprise Edition of Couchbase Server, or a Couchbase Capella account, before proceeding with configuring encryption on the client side.
+
+For TLS certificate verification the SDK uses the following CA certificates:
+
+* The certificates in the Mozilla Root CA bundle (bundled with the SDK as of 4.1.5 and obtained from https://curl.se/docs/caextract.html[curl])
+* The certificates in OpenSSL's default CA certificate store (as of SDK 4.1.0)
+* The self-signed root certificate that is used to sign the Couchbase Capella certificates (bundled with the SDK as of 4.0.0)
+
+The OpenSSL defaults can be overriden using the `SSL_CERT_DIR` and `SSL_CERT_FILE` environment variables. The `SSL_CERT_DIR` variable is used to set a specific directory in which the client should look for individual certificate files, whereas the `SSL_CERT_FILE` environment variable is used to point to a single file containing one or more certificates.
+
+Loading the Mozilla certificates can be disabled by setting the `disable_mozilla_ca_certificates` property of `ClusterOptions`.
+
+The {cbpp} core's metadata provide information on where OpenSSL's default certificate store is located,  which version of the Mozilla CA certificate store was bundled, and other useful details. You can get the metadata using the following command:
+
+====
+[source,console]
+----
+$ python -c "from couchbase import get_metadata; print(get_metadata(detailed=True))"
+----
+[source,console]
+----
+{
+ ...
+ 'mozilla_ca_bundle_date': 'Tue Jan 10 04:12:06 2023 GMT',
+ 'mozilla_ca_bundle_embedded': True,
+ 'mozilla_ca_bundle_sha256': 'fb1ecd641d0a02c01bc9036d513cb658bbda62a75e246bedbc01764560a639f0',
+ 'mozilla_ca_bundle_size': 137,
+ ...
+ 'openssl_default_cert_dir': '/opt/homebrew/etc/openssl@1.1/certs',
+ 'openssl_default_cert_dir_env': 'SSL_CERT_DIR',
+ 'openssl_default_cert_file': '/opt/homebrew/etc/openssl@1.1/cert.pem',
+ 'openssl_default_cert_file_env': 'SSL_CERT_FILE',
+ ...
+}
+----
+====
+
+With debug-level logging enabled, if the Mozilla certificates have been loaded, a message with the information on the version of the Mozilla CA certificate store will be output. For example:
+
+[source]
+----
+loading 137 CA certificates from Mozilla bundle. Update date: "Tue Jan 10 04:12:06 2023 GMT", SHA256: "fb1ecd641d0a02c01bc9036d513cb658bbda62a75e246bedbc01764560a639f0"
+----
 
 [{tabs}]
 ====
@@ -227,21 +269,7 @@ However, as the certificate is bundled with the SDK, it is trusted by default.
 Couchbase Server::
 +
 --
-As of SDK 4.1, if you connect to a Couchbase Server cluster with a root certificate issued by a trusted CA (Certificate Authority), you no longer need to configure the `cert_path` property in the `PasswordAuthenticator`.
-
-The cluster's root certificate just needs to be issued by a CA whose certificate is in your OpenSSL trust store.
-This can include publicly trusted CAs (e.g., GoDaddy, Verisign, etc...), plus any other CA certificates that you wish to add.
-The Python SDK uses https://github.com/couchbaselabs/couchbase-cxx-client[{cbpp}] internally to retrieve the root CAs.
-
-IMPORTANT: {cbpp} loads your platform's root CA store using OpenSSL, therefore you should make sure that your system or platform is configured to support this.
-
-Depending on your OpenSSL installation, OpenSSL might not contain any certificates in its CA store by default, which you might wish to populate.
-You can find Python's OpenSSL defaults with the following command.  Alternatively, you can configure the `SSL_CERT_DIR` or `SSL_CERT_FILE` environment variable to set the directory or root CA store file {cbpp} uses to retrieve root CAs.
-
-[source,console]
-----
-python -c "import ssl; print(ssl.get_default_verify_paths())"
-----
+Because certificates from the Mozilla Root CA store are bundled with the SDK, if the server’s certificate is signed by a well-known CA (e.g., GoDaddy, Verisign, etc.), you no longer need to configure the `cert_path` property in the `PasswordAuthenticator` -- simply use `couchbases://` in your connection string.
 
 You can still provide a certificate explicitly if necessary:
 


### PR DESCRIPTION
Updated the documentation on TLS certificates after the recent change to bundle the Mozilla CA certificates:
* Promoted some important information above the Capella/Server tabs (Environment variables)
* Listed the sources of CA certificates the SDK uses
* Explained how to get information on what version of the Mozilla CA cert bundle is being used
* Removed the paragraph talking about how the OpenSSL certificate store can be empty by default - this should no longer be an issue users run into now with the inclusion of the Mozilla certs