### PR TITLE
Changes for client version 4.1.9 release

### DIFF
--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -58,7 +58,7 @@ The https://cloud.couchbase.com/sign-up[Couchbase Capella free trial] version co
 
 == Quick Installation
 
-The SDK will run on Python 3.7 - 3.10.
+The SDK will run on xref:compatibility.adoc#python-version-compat[supported versions Python].
 A more detailed guide in our xref:project-docs:sdk-full-installation.adoc[Installation page] covers every supported platform, 
 but this section should be enough to get up and running for _most_ xref:compatibility.adoc#platform-compatibility[supported Operating Systems].
 
@@ -70,7 +70,7 @@ macOS 12 & 13::
 If you are running Catalina (macOS 10.15) -- or have other detailed requirements -- take a look at our xref:project-pages:sdk-full-installation.adoc[full installation guide].
 Otherwise, read on for a quick install on macOS _Big Sur_ or _Monterey_.
 
-As of the 4.0.1 release of the Python SDK, wheels are available for Python 3.7 - 3.10.
+The Python SDK has wheels are available on macOS for xref:compatibility.adoc#python-version-compat[supported versions of Python].
 
 First, make sure that your _brew_ package index is up-to-date:
 [source,console]
@@ -100,16 +100,19 @@ Now, install the Python SDK:
 ----
 $ sudo -H python3 -m pip install couchbase
 ----
+
+NOTE: Starting with Python 3.11.5, macOS installers from python.org now use https://docs.python.org/3/whatsnew/3.11.html#notable-changes-in-3-11-5[OpenSSL 3.0]. If using a version prior to 4.1.9 of the Python SDK, a potential side-effect of this change is an `ImportError: DLL load failed while importing pycbc_core` error. Upgrade the SDK to a version >= 4.1.9 to avoid this side-effect. If unable to upgrade, a work-around is to set the `PYCBC_OPENSSL_DIR` environment variable to the path where the OpenSSL 1.1 libraries (`libssl.1.1.dylib ` and `libcrypto.1.1.dylib`) can be found.
+
 --
 
 Red Hat & CentOS::
 +
 --
-Note, check that you have a supported version of Python (3.7 - 3.10).
+Note, check that you have a xref:compatibility.adoc#python-version-compat[supported version of Python].
 Suggestions for platforms with an outdated build chain, such as CentOS 7, can be found in our xref:project-docs:sdk-full-installation.adoc[Installation Guide].
 Assuming you have an updated build environment, follow these steps.
 
-As of the 4.0.2 release of the Python SDK, manylinux wheels are available for Python 3.7 - 3.10.
+The Python SDK has manylinux wheels available for xref:compatibility.adoc#python-version-compat[supported versions of Python].
 
 During first-time setup, install the prerequisites:
 
@@ -130,11 +133,11 @@ $ python3 -m pip install couchbase
 Debian & Ubuntu::
 +
 --
-Note, check that you have a supported version of Python (3.7 - 3.10).
+Note, check that you have a xref:compatibility.adoc#python-version-compat[supported version of Python].
 Suggestions for platforms with an outdated build chain, such as Debian 9, can be found in our xref:project-docs:sdk-full-installation.adoc[Installation Guide].
 Assuming you have an updated build environment, follow these steps.
 
-As of the 4.0.2 release of the Python SDK, manylinux wheels are available for Python 3.7 - 3.10.
+The Python SDK has manylinux wheels available for xref:compatibility.adoc#python-version-compat[supported versions of Python].
 
 During first-time setup, install the prerequisites:
 
@@ -160,17 +163,19 @@ Best practice is to use a Python virtual environment such as _venv_ or _pyenv_.
 
 TIP: Checkout the https://github.com/pyenv-win/pyenv-win[pyenv-win^] project to manage multiple versions of Python.
 
-Wheels are available on Windows for Python 3.7 - 3.10.
+The Python SDK has wheels available on Windows for xref:compatibility.adoc#python-version-compat[supported versions of Python].
 
 [source,console]
 ----
 python -m pip install couchbase
 ----
 
-The standard Python distributions for Windows include OpenSSL DLLs, as PIP and the inbuilt `ssl` module require it for correct operation.
-The binary wheels for Windows are packaged as a binary wheel built against OpenSSL.
+NOTE: Starting with Python 3.11.5, Windows builds from python.org now use https://docs.python.org/3/whatsnew/3.11.html#notable-changes-in-3-11-5[OpenSSL 3.0]. If using a version prior to 4.1.9 of the Python SDK, a potential side-effect of this change is an `ImportError: DLL load failed while importing pycbc_core` error. Upgrade the SDK to a version >= 4.1.9 to avoid this side-effect. If unable to upgrade, a work-around is to set the `PYCBC_OPENSSL_DIR` environment variable to the path where the OpenSSL 1.1 libraries (`libssl-1_1.dll` and `libcrypto-1_1.dll`) can be found.
 
-NOTE: If you require a version that doesn't have a suitable binary wheel on PyPi, follow the https://github.com/couchbase/couchbase-python-client#alternative-installation-methods[build instructions] on the GitHub repo.
+The standard Python distributions for Windows include OpenSSL DLLs, as PIP and the inbuilt `ssl` module require it for correct operation.
+Prior to version 4.1.9 of the Python SDK, the binary wheels for Windows are built against OpenSSL 1.1.  Version 4.1.9 and beyond statically link against BoringSSL thus removing the OpenSSL requirement.
+
+NOTE: If you require a version that doesn't have a suitable binary wheel on PyPI, follow the https://github.com/couchbase/couchbase-python-client#alternative-installation-methods[build instructions] on the GitHub repo.
 --
 ====
 

--- a/modules/howtos/pages/subdocument-operations.adoc
+++ b/modules/howtos/pages/subdocument-operations.adoc
@@ -67,6 +67,8 @@ The paths `name`, `addresses.billing.country` and `purchases.complete[0]` are al
 
 == Retrieving
 
+IMPORTANT: The `lookup_in` method expects an `Iterable` of Sub-Document `Spec` (see https://docs.couchbase.com/sdk-api/couchbase-python-client/couchbase_api/couchbase_core.html?highlight=collection%20lookup_in#couchbase.collection.Collection.lookup_in[API reference doc]).  The examples below show how either a list or a tuple might be used.  If using a tuple with only a single Sub-Document `Spec` **be sure** to include the trailing comma.
+
 The _lookup_in_ operations query the document for certain path(s); these path(s) are then returned.
 You have a choice of actually retrieving the document path using the _get_ Sub-Document operation, or simply querying the existence of the path using the _exists_ Sub-Document operation.
 The latter saves even more bandwidth by not retrieving the contents of the path if it is not needed.
@@ -92,6 +94,8 @@ include::howtos:example$subdocument_ops.py[tag=lookup_in_multi]
 ----
 
 == Mutating
+
+IMPORTANT: The `mutate_in` method expects an `Iterable` of Sub-Document `Spec` (see https://docs.couchbase.com/sdk-api/couchbase-python-client/couchbase_api/couchbase_core.html?highlight=collection%20mutate_in#couchbase.collection.Collection.mutate_in[API reference doc]).  The examples below show how either a list or a tuple might be used.  If using a tuple with only a single Sub-Document `Spec` **be sure** to include the trailing comma.
 
 Mutation operations modify one or more paths in the document.
 The simplest of these operations is _upsert_, which, similar to the fulldoc-level _upsert_, will either modify the value of an existing path or create it if it does not exist:

--- a/modules/project-docs/pages/sdk-full-installation.adoc
+++ b/modules/project-docs/pages/sdk-full-installation.adoc
@@ -34,7 +34,8 @@ The Couchbase SDK 3.x API (used in the Python SDK 3.0 - 4.0) is a complete rewri
 Couchbase Python SDK bundles Couchbase++ automatically, so no need to install it separately.
 You may need CMake (a version >= 3.18) to install, although the installer will attempt to download it from PyPI automatically.
 
-The Python SDK 4.x requires Python 3. See the xref:project-docs:compatibility.adoc#python-version-compat[Python Version Compatibility] section for details on supported versions of Python.
+The Python SDK 4.x requires Python 3. 
+See the xref:project-docs:compatibility.adoc#python-version-compat[Python Version Compatibility] section for details on supported versions of Python.
 
 [NOTE]
 ====
@@ -62,7 +63,7 @@ macOS::
 --
 Best practice is to use a Python virtual environment such as _venv_ or _pyenv_ to manage multible versions of Python, but in cases where this is not practicable follow the `brew` steps below, and also modify your `$PATH` as shown.
 
-The Python SDK has wheels are available on macOS for xref:compatibility.adoc#python-version-compat[supported versions of Python].
+The Python SDK has wheels available on macOS for xref:compatibility.adoc#python-version-compat[supported versions of Python].
 
 NOTE: There can be a problem when using the Python (3.8.2) that ships with Xcode on Catalina. 
 It is advised to install Python via https://github.com/pyenv/pyenv#homebrew-on-macos[pyenv^]
@@ -112,7 +113,10 @@ Install the latest Python SDK:
 $ sudo -H python3 -m pip install couchbase
 ----
 
-NOTE: Starting with Python 3.11.5, macOS installers from python.org now use https://docs.python.org/3/whatsnew/3.11.html#notable-changes-in-3-11-5[OpenSSL 3.0]. If using a version prior to 4.1.9 of the Python SDK, a potential side-effect of this change is an `ImportError: DLL load failed while importing pycbc_core` error. Upgrade the SDK to a version >= 4.1.9 to avoid this side-effect. If unable to upgrade, a work-around is to set the `PYCBC_OPENSSL_DIR` environment variable to the path where the OpenSSL 1.1 libraries (`libssl.1.1.dylib ` and `libcrypto.1.1.dylib`) can be found.
+NOTE: Starting with Python 3.11.5, macOS installers from python.org now use https://docs.python.org/3/whatsnew/3.11.html#notable-changes-in-3-11-5[OpenSSL 3.0]. 
+If using a version prior to 4.1.9 of the Python SDK, a potential side-effect of this change is an `ImportError: DLL load failed while importing pycbc_core` error. 
+Upgrade the SDK to a version >= 4.1.9 to avoid this side-effect. 
+If unable to upgrade, a work-around is to set the `PYCBC_OPENSSL_DIR` environment variable to the path where the OpenSSL 1.1 libraries (`libssl.1.1.dylib ` and `libcrypto.1.1.dylib`) can be found.
 
 --
 
@@ -229,10 +233,14 @@ Install the latest Python SDK:
 python -m pip install couchbase
 ----
 
-NOTE: Starting with Python 3.11.5, Windows builds from python.org now use https://docs.python.org/3/whatsnew/3.11.html#notable-changes-in-3-11-5[OpenSSL 3.0]. If using a version prior to 4.1.9 of the Python SDK, a potential side-effect of this change is an `ImportError: DLL load failed while importing pycbc_core` error. Upgrade the SDK to a version >= 4.1.9 to avoid this side-effect. If unable to upgrade, a work-around is to set the `PYCBC_OPENSSL_DIR` environment variable to the path where the OpenSSL 1.1 libraries (`libssl-1_1.dll` and `libcrypto-1_1.dll`) can be found.
+NOTE: Starting with Python 3.11.5, Windows builds from python.org now use https://docs.python.org/3/whatsnew/3.11.html#notable-changes-in-3-11-5[OpenSSL 3.0]. 
+If using a version prior to 4.1.9 of the Python SDK, a potential side-effect of this change is an `ImportError: DLL load failed while importing pycbc_core` error. 
+Upgrade the SDK to a version >= 4.1.9 to avoid this side-effect. 
+If unable to upgrade, a work-around is to set the `PYCBC_OPENSSL_DIR` environment variable to the path where the OpenSSL 1.1 libraries (`libssl-1_1.dll` and `libcrypto-1_1.dll`) can be found.
 
 The standard Python distributions for Windows include OpenSSL DLLs, as PIP and the inbuilt `ssl` module require it for correct operation.
-Prior to version 4.1.9 of the Python SDK, the binary wheels for Windows are built against OpenSSL 1.1.  Version 4.1.9 and beyond statically link against BoringSSL thus removing the OpenSSL requirement.
+Prior to version 4.1.9 of the Python SDK, the binary wheels for Windows are built against OpenSSL 1.1. 
+Version 4.1.9 and beyond statically link against BoringSSL thus removing the OpenSSL requirement.
 
 NOTE: If you require a version that doesn't have a suitable binary wheel on PyPI, follow the https://github.com/couchbase/couchbase-python-client#alternative-installation-methods[build instructions] on the GitHub repo.
 --

--- a/modules/project-docs/pages/sdk-full-installation.adoc
+++ b/modules/project-docs/pages/sdk-full-installation.adoc
@@ -34,7 +34,7 @@ The Couchbase SDK 3.x API (used in the Python SDK 3.0 - 4.0) is a complete rewri
 Couchbase Python SDK bundles Couchbase++ automatically, so no need to install it separately.
 You may need CMake (a version >= 3.18) to install, although the installer will attempt to download it from PyPI automatically.
 
-The Python SDK 4.x requires Python 3, with versions 3.7 - 3.10 supported. See the xref:project-docs:compatibility.adoc#python-version-compat[Compatibility] section for details.
+The Python SDK 4.x requires Python 3. See the xref:project-docs:compatibility.adoc#python-version-compat[Python Version Compatibility] section for details on supported versions of Python.
 
 [NOTE]
 ====
@@ -62,7 +62,7 @@ macOS::
 --
 Best practice is to use a Python virtual environment such as _venv_ or _pyenv_ to manage multible versions of Python, but in cases where this is not practicable follow the `brew` steps below, and also modify your `$PATH` as shown.
 
-As of the 4.0.1 release of the Python SDK, wheels are available for Python 3.7 - 3.10.
+The Python SDK has wheels are available on macOS for xref:compatibility.adoc#python-version-compat[supported versions of Python].
 
 NOTE: There can be a problem when using the Python (3.8.2) that ships with Xcode on Catalina. 
 It is advised to install Python via https://github.com/pyenv/pyenv#homebrew-on-macos[pyenv^]
@@ -100,6 +100,10 @@ $ echo 'export PATH="/usr/local/bin:"$PATH' >> ~/.zshrc
 $ brew install openssl@1.1
 ----
 
+[source,console]
+----
+$ source ~/.zshrc
+----
 
 Install the latest Python SDK:
 
@@ -107,6 +111,9 @@ Install the latest Python SDK:
 ----
 $ sudo -H python3 -m pip install couchbase
 ----
+
+NOTE: Starting with Python 3.11.5, macOS installers from python.org now use https://docs.python.org/3/whatsnew/3.11.html#notable-changes-in-3-11-5[OpenSSL 3.0]. If using a version prior to 4.1.9 of the Python SDK, a potential side-effect of this change is an `ImportError: DLL load failed while importing pycbc_core` error. Upgrade the SDK to a version >= 4.1.9 to avoid this side-effect. If unable to upgrade, a work-around is to set the `PYCBC_OPENSSL_DIR` environment variable to the path where the OpenSSL 1.1 libraries (`libssl.1.1.dylib ` and `libcrypto.1.1.dylib`) can be found.
+
 --
 
 Debian & Ubuntu::
@@ -116,12 +123,12 @@ This SDK runs on top of the {cpp} core, Couchbase{plus}{plus}, which requires a 
 
 IMPORTANT:  While workarounds are available for installing a newer build chain, some may not be within your company’s policy, so also take a look at container options -- such as the unofficial Docker builds provided in the Python SDK 4.x examples folder https://github.com/couchbase/couchbase-python-client/tree/master/examples/dockerfiles[here^], which can at least be used as a reference to a known working set-up.
 
-Check that you have a new enough release of Python (3.7 - 3.10).
+Check that you have a new enough release of Python.
 
 Best practice is to use a Python virtual environment such as _venv_ or _pyenv_ to manage multible versions of Python. 
 See https://github.com/pyenv/pyenv#basic-github-checkout[pyenv docs^] for details.
 
-As of the 4.0.2 release of the Python SDK, manylinux wheels are available for Python 3.7 - 3.10.
+The Python SDK has manylinux wheels available for xref:compatibility.adoc#python-version-compat[supported versions of Python].
 
 During first-time setup:
 
@@ -154,12 +161,12 @@ This SDK runs on top of the {cpp} core, Couchbase{plus}{plus}, which requires a 
 
 IMPORTANT:  Workarounds are available for installing a newer build chain with https://fedoraproject.org/wiki/EPEL[EPEL^], but this may not be within your company’s policy, so also take a look at container options -- such as the unofficial Docker builds provided in the Python SDK 4.x examples folder https://github.com/couchbase/couchbase-python-client/tree/master/examples/dockerfiles[here^], which can at least be used as a reference to a known working set-up.
 
-Check that you have a new enough release of Python (3.7 - 3.10), and if not then investigate the https://fedoraproject.org/wiki/EPEL[EPEL^] repository.
+Check that you have a new enough release of Python, and if not then investigate the https://fedoraproject.org/wiki/EPEL[EPEL^] repository.
 
 Best practice is to use a Python virtual environment such as _venv_ or _pyenv_ to manage multible versions of Python. 
 See https://github.com/pyenv/pyenv#basic-github-checkout[pyenv docs^] for details.
 
-As of the 4.0.2 release of the Python SDK, manylinux wheels are available for Python 3.7 - 3.10.
+The Python SDK has manylinux wheels available for xref:compatibility.adoc#python-version-compat[supported versions of Python].
 
 During first-time setup:
 
@@ -209,23 +216,25 @@ Best practice is to use a Python virtual environment such as _venv_ or _pyenv_.
 
 TIP: Checkout the https://github.com/pyenv-win/pyenv-win[pyenv-win^] project to manage multiple versions of Python.
 
-Wheels are available on Windows for Python 3.7 - 3.10.
+The Python SDK has wheels available on Windows for xref:compatibility.adoc#python-version-compat[supported versions of Python].
 
 First, make sure the <<microsoft-windows, requirements>> have been installed.
 
 NOTE: Commands assume user is working within a virtual environment.
 
-Install the latest Python SDK (if using Python 3.7 - 3.10):
+Install the latest Python SDK:
 
 [source,console]
 ----
 python -m pip install couchbase
 ----
 
-The standard Python distributions for Windows include OpenSSL DLLs, as PIP and the inbuilt `ssl` module require it for correct operation.
-The binary wheels for Windows are packaged as a binary wheel built against OpenSSL.
+NOTE: Starting with Python 3.11.5, Windows builds from python.org now use https://docs.python.org/3/whatsnew/3.11.html#notable-changes-in-3-11-5[OpenSSL 3.0]. If using a version prior to 4.1.9 of the Python SDK, a potential side-effect of this change is an `ImportError: DLL load failed while importing pycbc_core` error. Upgrade the SDK to a version >= 4.1.9 to avoid this side-effect. If unable to upgrade, a work-around is to set the `PYCBC_OPENSSL_DIR` environment variable to the path where the OpenSSL 1.1 libraries (`libssl-1_1.dll` and `libcrypto-1_1.dll`) can be found.
 
-NOTE: If you require a version that doesn't have a suitable binary wheel on PyPi, follow the https://github.com/couchbase/couchbase-python-client#alternative-installation-methods[build instructions] on the GitHub repo.
+The standard Python distributions for Windows include OpenSSL DLLs, as PIP and the inbuilt `ssl` module require it for correct operation.
+Prior to version 4.1.9 of the Python SDK, the binary wheels for Windows are built against OpenSSL 1.1.  Version 4.1.9 and beyond statically link against BoringSSL thus removing the OpenSSL requirement.
+
+NOTE: If you require a version that doesn't have a suitable binary wheel on PyPI, follow the https://github.com/couchbase/couchbase-python-client#alternative-installation-methods[build instructions] on the GitHub repo.
 --
 
 Conda::
@@ -253,7 +262,7 @@ Install the SDK:
 python -m pip install couchbase
 ----
 
-NOTE: If you require a version that doesn't have a suitable binary wheel on PyPi, follow the https://github.com/couchbase/couchbase-python-client#alternative-installation-methods[build instructions] on the GitHub repo.
+NOTE: If you require a version that doesn't have a suitable binary wheel on PyPI, follow the https://github.com/couchbase/couchbase-python-client#alternative-installation-methods[build instructions] on the GitHub repo.
 --
 ====
 // end::install[]

--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -44,6 +44,75 @@ All patch releases for each dot minor release should be API compatible, and safe
 any changes to expected behavior are noted in the release notes that follow.
 
 
+=== Version 4.1.9 (14 November 2023)
+
+Version 4.1.9 is the next patch release of the fourth generation Python SDK, bringing a number of improvements. Most notably the 4.1.9 release removes the `OpenSSL` dependency for published wheels and added _musllinux_ wheels for supported alpine environments.
+
+[source,bash]
+----
+$ python3 -m pip install couchbase==4.1.9
+----
+
+*API Docs:* http://docs.couchbase.com/sdk-api/couchbase-python-client-4.1.9/
+
+==== Behavioral Change
+
+The Couchbase Python SDK now publishes wheels that statically link against BoringSSL.  The change removes the `OpenSSL` requirement from the SDK when using a published wheel. If building the SDK from source, the build will default to dynamically linking with the system provided `OpenSSL`.  Build options are availalbe if wanting to build from source and statically link against BoringSSL.  Also, published wheels dynamically link against stdlibs where previously the default was to statically link against stdlibs.  Build options are available if wanting to build from source and statically link against stdlibs.
+
+==== Fixes
+
+* https://issues.couchbase.com/browse/PYCBC-1538[PYCBC-1538]:
+Fixed `get` with projections to not fail with `InvalidArgumentException` when projecting on more than 16 fields.
+
+* https://issues.couchbase.com/browse/PYCBC-1534[PYCBC-1534]:
+Fixed `MutateIn` replace operation to not fail if path is empty.
+
+* https://issues.couchbase.com/browse/PYCBC-1531[PYCBC-1531]:
+Fixed `CollectionQueryIndexManager` to raise `InvalidArgumentException` when `scope_name` or `collection_name` options are set.
+
+* https://issues.couchbase.com/browse/PYCBC-1521[PYCBC-1521]:
+Fixed streaming APIs to use cluster timeout values from `ClusterTimeoutOptions` if provided.
+
+==== Enhancements
+
+* https://issues.couchbase.com/browse/PYCBC-1536[PYCBC-1536]:
+Updated MANIFEST.in to only include necessary files for source install.
+
+* https://issues.couchbase.com/browse/PYCBC-1518[PYCBC-1520];
+https://issues.couchbase.com/browse/PYCBC-1520[PYCBC-1518]:
+Updated published wheels to statically link against BoringSSL.
+
+* https://issues.couchbase.com/browse/PYCBC-1515[PYCBC-1515]:
+Added support for bucket settings for 'no dedup' feature.
+
+* https://issues.couchbase.com/browse/PYCBC-1512[PYCBC-1512]:
+Reduced default HTTP Idle Timeout.
+
+* https://issues.couchbase.com/browse/PYCBC-1495[PYCBC-1495]:
+Updated wheels and build to dynamically link against stdlibs by default.
+
+==== Underlying C++ SDK Core Changes
+
+* https://issues.couchbase.com/browse/CXXCBC-387[CXXCBC-387]:
+Optimising tags for `noop_tracer` and cache formatted `mbcp_session` endpoints (https://github.com/couchbaselabs/couchbase-cxx-client/pull/461[#461], https://github.com/couchbaselabs/couchbase-cxx-client/pull/462[#462], https://github.com/couchbaselabs/couchbase-cxx-client/pull/464[#464]).
+* https://issues.couchbase.com/browse/CXXCBC-383[CXXCBC-383]:
+Map `subdoc_doc_too_deep`` KV status to `path_too_deep`` error code (https://github.com/couchbaselabs/couchbase-cxx-client/pull/455[#455]).
+* https://issues.couchbase.com/browse/CXXCBC-377[CXXCBC-377]:
+Implement ExtParallelUnstaging in transactions (https://github.com/couchbaselabs/couchbase-cxx-client/pull/457[#457]).
+* https://issues.couchbase.com/browse/CXXCBC-386[CXXCBC-386]:
+Allow option to statically link against BoringSSL (https://github.com/couchbaselabs/couchbase-cxx-client/pull/458[#458], https://github.com/couchbaselabs/couchbase-cxx-client/pull/465[#465], https://github.com/couchbaselabs/couchbase-cxx-client/pull/471[#471], https://github.com/couchbaselabs/couchbase-cxx-client/pull/474[#474], https://github.com/couchbaselabs/couchbase-cxx-client/pull/478[#478]).
+* https://issues.couchbase.com/browse/CXXCBC-376[CXXCBC-376]:
+Revisit what 'create' and 'update' bucket operations send to the server. Make optional bucket settings fields optional, and do not send anything unless the settings explicitly specified (https://github.com/couchbaselabs/couchbase-cxx-client/pull/451[#451]).
+* https://issues.couchbase.com/browse/CXXCBC-374[CXXCBC-374]:
+Return 'bucket_exists' error when the bucket already exists during 'create' operation (https://github.com/couchbaselabs/couchbase-cxx-client/pull/449[#449]).
+* https://issues.couchbase.com/browse/CXXCBC-359[CXXCBC-359]:
+Reduce default HTTP idle timeout to 1 second (https://github.com/couchbaselabs/couchbase-cxx-client/pull/448[#448]).
+* https://issues.couchbase.com/browse/CXXCBC-367[CXXCBC-367];
+https://issues.couchbase.com/browse/CXXCBC-370[CXXCBC-370]:
+Add history retention settings to buckets/collection management (https://github.com/couchbaselabs/couchbase-cxx-client/pull/446[#446]).
+* https://issues.couchbase.com/browse/CXXCBC-119[CXXCBC-119]:
+Return booleans for subdocument 'exists' operation instead of error code (https://github.com/couchbaselabs/couchbase-cxx-client/pull/444[#444], https://github.com/couchbaselabs/couchbase-cxx-client/pull/452[#452]).
+* Add more information to diagnose timeouts on NMVB responses (https://github.com/couchbaselabs/couchbase-cxx-client/pull/475[#475]).
 
 === Version 4.1.8 (25 August 2023)
 

--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -46,7 +46,8 @@ any changes to expected behavior are noted in the release notes that follow.
 
 === Version 4.1.9 (14 November 2023)
 
-Version 4.1.9 is the next patch release of the fourth generation Python SDK, bringing a number of improvements. Most notably the 4.1.9 release removes the `OpenSSL` dependency for published wheels and added _musllinux_ wheels for supported alpine environments.
+Version 4.1.9 is the next patch release of the fourth generation Python SDK, bringing a number of improvements. 
+Most notably the 4.1.9 release removes the `OpenSSL` dependency for published wheels and added _musllinux_ wheels for supported alpine environments.
 
 [source,bash]
 ----
@@ -57,7 +58,12 @@ $ python3 -m pip install couchbase==4.1.9
 
 ==== Behavioral Change
 
-The Couchbase Python SDK now publishes wheels that statically link against BoringSSL.  The change removes the `OpenSSL` requirement from the SDK when using a published wheel. If building the SDK from source, the build will default to dynamically linking with the system provided `OpenSSL`.  Build options are availalbe if wanting to build from source and statically link against BoringSSL.  Also, published wheels dynamically link against stdlibs where previously the default was to statically link against stdlibs.  Build options are available if wanting to build from source and statically link against stdlibs.
+The Couchbase Python SDK now publishes wheels that statically link against BoringSSL.  
+The change removes the `OpenSSL` requirement from the SDK when using a published wheel. 
+If building the SDK from source, the build will default to dynamically linking with the system provided `OpenSSL`.  
+Build options are availalbe if wanting to build from source and statically link against BoringSSL.  
+Also, published wheels dynamically link against stdlibs where previously the default was to statically link against stdlibs.  
+Build options are available if wanting to build from source and statically link against stdlibs.
 
 ==== Fixes
 
@@ -78,7 +84,7 @@ Fixed streaming APIs to use cluster timeout values from `ClusterTimeoutOptions` 
 * https://issues.couchbase.com/browse/PYCBC-1536[PYCBC-1536]:
 Updated MANIFEST.in to only include necessary files for source install.
 
-* https://issues.couchbase.com/browse/PYCBC-1518[PYCBC-1520];
+* https://issues.couchbase.com/browse/PYCBC-1518[PYCBC-1520],
 https://issues.couchbase.com/browse/PYCBC-1520[PYCBC-1518]:
 Updated published wheels to statically link against BoringSSL.
 
@@ -96,23 +102,26 @@ Updated wheels and build to dynamically link against stdlibs by default.
 * https://issues.couchbase.com/browse/CXXCBC-387[CXXCBC-387]:
 Optimising tags for `noop_tracer` and cache formatted `mbcp_session` endpoints (https://github.com/couchbaselabs/couchbase-cxx-client/pull/461[#461], https://github.com/couchbaselabs/couchbase-cxx-client/pull/462[#462], https://github.com/couchbaselabs/couchbase-cxx-client/pull/464[#464]).
 * https://issues.couchbase.com/browse/CXXCBC-383[CXXCBC-383]:
-Map `subdoc_doc_too_deep`` KV status to `path_too_deep`` error code (https://github.com/couchbaselabs/couchbase-cxx-client/pull/455[#455]).
+Map `subdoc_doc_too_deep` KV status to `path_too_deep` error code (https://github.com/couchbaselabs/couchbase-cxx-client/pull/455[#455]).
 * https://issues.couchbase.com/browse/CXXCBC-377[CXXCBC-377]:
-Implement ExtParallelUnstaging in transactions (https://github.com/couchbaselabs/couchbase-cxx-client/pull/457[#457]).
+Implement `ExtParallelUnstaging` in transactions (https://github.com/couchbaselabs/couchbase-cxx-client/pull/457[#457]).
 * https://issues.couchbase.com/browse/CXXCBC-386[CXXCBC-386]:
 Allow option to statically link against BoringSSL (https://github.com/couchbaselabs/couchbase-cxx-client/pull/458[#458], https://github.com/couchbaselabs/couchbase-cxx-client/pull/465[#465], https://github.com/couchbaselabs/couchbase-cxx-client/pull/471[#471], https://github.com/couchbaselabs/couchbase-cxx-client/pull/474[#474], https://github.com/couchbaselabs/couchbase-cxx-client/pull/478[#478]).
 * https://issues.couchbase.com/browse/CXXCBC-376[CXXCBC-376]:
-Revisit what 'create' and 'update' bucket operations send to the server. Make optional bucket settings fields optional, and do not send anything unless the settings explicitly specified (https://github.com/couchbaselabs/couchbase-cxx-client/pull/451[#451]).
+Revisit what 'create' and 'update' bucket operations send to the server. 
+Make optional bucket settings fields optional, and do not send anything unless the settings explicitly specified (https://github.com/couchbaselabs/couchbase-cxx-client/pull/451[#451]).
 * https://issues.couchbase.com/browse/CXXCBC-374[CXXCBC-374]:
 Return 'bucket_exists' error when the bucket already exists during 'create' operation (https://github.com/couchbaselabs/couchbase-cxx-client/pull/449[#449]).
 * https://issues.couchbase.com/browse/CXXCBC-359[CXXCBC-359]:
-Reduce default HTTP idle timeout to 1 second (https://github.com/couchbaselabs/couchbase-cxx-client/pull/448[#448]).
+Reduced the default timeout for idle HTTP connections to 1 second. 
+The previous default (4.5 seconds) was too close to the 5-second server-side timeout, and could lead to spurious request failures (https://github.com/couchbaselabs/couchbase-cxx-client/pull/448[#448]).
 * https://issues.couchbase.com/browse/CXXCBC-367[CXXCBC-367];
 https://issues.couchbase.com/browse/CXXCBC-370[CXXCBC-370]:
-Add history retention settings to buckets/collection management (https://github.com/couchbaselabs/couchbase-cxx-client/pull/446[#446]).
+Added history retention settings to buckets/collection management (https://github.com/couchbaselabs/couchbase-cxx-client/pull/446[#446]).
 * https://issues.couchbase.com/browse/CXXCBC-119[CXXCBC-119]:
 Return booleans for subdocument 'exists' operation instead of error code (https://github.com/couchbaselabs/couchbase-cxx-client/pull/444[#444], https://github.com/couchbaselabs/couchbase-cxx-client/pull/452[#452]).
 * Add more information to diagnose timeouts on NMVB responses (https://github.com/couchbaselabs/couchbase-cxx-client/pull/475[#475]).
+
 
 === Version 4.1.8 (25 August 2023)
 


### PR DESCRIPTION
- release notes for client version 4.1.9
- added note for subdoc Spec types
- updated installation instructions for supported Python versions
- made note on macOS and Windows for Python 3.11.5 changes