### PR TITLE
[AV-82442] Update Python release 4.2 docs for Free Tier

### DIFF
--- a/modules/hello-world/pages/sample-application.adoc
+++ b/modules/hello-world/pages/sample-application.adoc
@@ -310,6 +310,6 @@ include::example$sample-app.py[tag=search-subdoc, indent=0]
 
 == Next Steps
 
-* Sign up for your free xref:cloud:ROOT:index.adoc[Capella trial acocunt], to get started with Couchbase the easy way.
+* Sign up for a xref:cloud:ROOT:index.adoc[Capella account] and deploy a perpetual free operational cluster to get started with Couchbase the easy way.
 * Read more about interacting with the Couchbase services used in this example -- xref:howtos:kv-operations.adoc[Data (K/V)], xref:howtos:subdocument-operations.adoc[Sub-Document], xref:howtos:n1ql-queries-with-sdk.adoc[Query], and xref:howtos:full-text-searching-with-sdk.adoc[Search].
 * Discover xref:howtos:distributed-acid-transactions-from-the-sdk.adoc[Distributed ACID Transactions] from the Python SDK, for cases where several documentations (such as combined flight and hotel bookings) must succeed together.

--- a/modules/hello-world/pages/sample-application.adoc
+++ b/modules/hello-world/pages/sample-application.adoc
@@ -310,6 +310,6 @@ include::example$sample-app.py[tag=search-subdoc, indent=0]
 
 == Next Steps
 
-* Sign up for a xref:cloud:ROOT:index.adoc[Capella account] and deploy a perpetual free operational cluster to get started with Couchbase the easy way.
+* Sign up for your free xref:cloud:ROOT:index.adoc[Capella trial acocunt], to get started with Couchbase the easy way.
 * Read more about interacting with the Couchbase services used in this example -- xref:howtos:kv-operations.adoc[Data (K/V)], xref:howtos:subdocument-operations.adoc[Sub-Document], xref:howtos:n1ql-queries-with-sdk.adoc[Query], and xref:howtos:full-text-searching-with-sdk.adoc[Search].
 * Discover xref:howtos:distributed-acid-transactions-from-the-sdk.adoc[Distributed ACID Transactions] from the Python SDK, for cases where several documentations (such as combined flight and hotel bookings) must succeed together.

--- a/modules/hello-world/pages/sample-application.adoc
+++ b/modules/hello-world/pages/sample-application.adoc
@@ -310,6 +310,6 @@ include::example$sample-app.py[tag=search-subdoc, indent=0]
 
 == Next Steps
 
-* Sign up for a xref:cloud:ROOT:index.adoc[Capella account] and deploy a perpetual free operational cluster to get started with Couchbase the easy way.
+* Sign up for a xref:cloud:ROOT:index.adoc[Capella account] and deploy a free operational cluster to get started with Couchbase the easy way.
 * Read more about interacting with the Couchbase services used in this example -- xref:howtos:kv-operations.adoc[Data (K/V)], xref:howtos:subdocument-operations.adoc[Sub-Document], xref:howtos:n1ql-queries-with-sdk.adoc[Query], and xref:howtos:full-text-searching-with-sdk.adoc[Search].
 * Discover xref:howtos:distributed-acid-transactions-from-the-sdk.adoc[Distributed ACID Transactions] from the Python SDK, for cases where several documentations (such as combined flight and hotel bookings) must succeed together.

--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -197,7 +197,7 @@ Couchbase Capella::
 * You have signed up to https://cloud.couchbase.com/sign-up[Couchbase Capella].
 
 * You have created your own bucket, or loaded the Travel Sample dataset.
-Note, the Travel Sample dataset is installed automatically when deploying a Capella perpetual free tier cluster.
+Note, the Travel Sample dataset is installed automatically when deploying a Capella free tier cluster.
 
 * A user is created with permissions to access the cluster (at least Application Access permissions).
 See the xref:cloud:get-started:cluster-and-data.adoc#credentials[Capella connection page] for more details.

--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -54,7 +54,7 @@ or the xref:{version-server}@server:manage:manage-settings/install-sample-bucket
 --
 ====
 
-The https://cloud.couchbase.com/sign-up[Couchbase Capella free tier] version comes with the Travel Sample Bucket, and its Query indexes, loaded and ready.
+The https://cloud.couchbase.com/sign-up[Couchbase Capella free trial] version comes with the Travel Sample Bucket, and its Query indexes, loaded and ready.
 
 == Quick Installation
 
@@ -197,7 +197,7 @@ Couchbase Capella::
 * You have signed up to https://cloud.couchbase.com/sign-up[Couchbase Capella].
 
 * You have created your own bucket, or loaded the Travel Sample dataset.
-Note, the Travel Sample dataset is installed automatically when deploying a Capella perpetual free tier cluster.
+Note, the Travel Sample dataset is installed automatically by the Capella free trial.
 
 * A user is created with permissions to access the cluster (at least Application Access permissions).
 See the xref:cloud:get-started:cluster-and-data.adoc#credentials[Capella connection page] for more details.

--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -54,7 +54,7 @@ or the xref:{version-server}@server:manage:manage-settings/install-sample-bucket
 --
 ====
 
-The https://cloud.couchbase.com/sign-up[Couchbase Capella free trial] version comes with the Travel Sample Bucket, and its Query indexes, loaded and ready.
+The https://cloud.couchbase.com/sign-up[Couchbase Capella free tier] version comes with the Travel Sample Bucket, and its Query indexes, loaded and ready.
 
 == Quick Installation
 
@@ -197,7 +197,7 @@ Couchbase Capella::
 * You have signed up to https://cloud.couchbase.com/sign-up[Couchbase Capella].
 
 * You have created your own bucket, or loaded the Travel Sample dataset.
-Note, the Travel Sample dataset is installed automatically by the Capella free trial.
+Note, the Travel Sample dataset is installed automatically when deploying a Capella perpetual free tier cluster.
 
 * A user is created with permissions to access the cluster (at least Application Access permissions).
 See the xref:cloud:get-started:cluster-and-data.adoc#credentials[Capella connection page] for more details.


### PR DESCRIPTION
Removed mentions of trial in the Python SDK docs. Only locations found were the start-using-sdk.adoc page and the sample-application page.